### PR TITLE
CoordTrans bug fixes and localization update

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/Flyout.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/Flyout.js
@@ -29,7 +29,6 @@ Oskari.clazz.define('Oskari.coordinatetransformation.Flyout',
             this.template = jQuery();
             this.flyout = jQuery(this.container.parentElement.parentElement);
             this.flyout.addClass('coordinatetransformation-flyout');
-            this.setContainerMaxHeight(Oskari.getSandbox().getMap().getHeight());
         },
         setContainerMaxHeight: function (mapHeight) {
             // calculate max-height based on map size

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
@@ -364,15 +364,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
             }
             return false;
         },
-        selectMapProjection: function () {
+        selectMapProjection: function (showProjection) {
             var srsOptions = this.helper.getMapEpsgValues();
             var selects = this.selectInstances;
             if (srsOptions) {
                 selects.datum.setValue(srsOptions.datum);
                 selects.coordinate.setValue(srsOptions.coord);
                 if (srsOptions.coord === 'COORD_PROJ_2D') {
-                    this.showProjectionSelect(true);
                     selects.projection.setValue(srsOptions.proj);
+                    this.showProjectionSelect(showProjection, true);
                 }
                 selects['geodetic-coordinate'].setValue(srsOptions.srs);
                 // TODO

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
@@ -6,7 +6,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
         this.sources = ['keyboard', 'file', 'map'];
         this.sourceElems = {};
         this.sourceSelection = null;
+        this.systemInfo = Oskari.clazz.create('Oskari.coordinatetransformation.view.CoordinateSystemInformation');
         this._template = {
+            // TODO remove unused sourceWrapper and source. also remove 2 from names and commented codes
             sourceWrapper: jQuery('<div class="datasource-wrapper"></div>'),
             source: _.template(
                 '<h4>${title}</h4>' +
@@ -132,13 +134,13 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
             // });
             // sourceWrapper.append(actions);
             this.setElement(container);
+            this.bindInfoLinks();
         },
         bindClickHandler: function (elem, value) {
             var me = this;
             elem.on('click', function () {
                 // elem.find('input').trigger('click');
-                var currentValue = me.sourceSelection;
-                if (currentValue !== value) {
+                if (me.sourceSelection !== value) {
                     /* elem.addClass('selected');
                     elem.find('.action').removeClass('oskari-hidden');
                     if (currentValue !== null){
@@ -149,6 +151,13 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                 } else {
                     me.trigger('SourceSelectClick', me.sourceSelection);
                 }
+            });
+        },
+        bindInfoLinks: function () {
+            var me = this;
+            this.getElement().find('.infolink').on('click', function (event) {
+                var key = this.dataset.source;
+                me.systemInfo.show(jQuery(this), key, true);
             });
         },
         selectSource: function (value) {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -159,7 +159,10 @@ Oskari.clazz.define('Oskari.coordinatetransformation.instance',
                     return;
                 }
                 var state = event.getViewState();
-                if (state === 'attach' || state === 'restore') {
+                if (state === 'attach') {
+                    this.plugins['Oskari.userinterface.Flyout'].setContainerMaxHeight(Oskari.getSandbox().getMap().getHeight());
+                    this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
+                } else if (state === 'restore') {
                     this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
                 } else if (state === 'close' || state === 'minimize') {
                     this.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -23,6 +23,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.instance',
         this.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
         this.isMapSelection = false;
         this.isRemoveMarkers = false;
+        this.flyoutAttached = false; // hack, because drag also fires attach
         this.sandbox = Oskari.getSandbox();
         // TODO should dimensions be handled by dataHandler
         this.dimensions = {
@@ -159,12 +160,16 @@ Oskari.clazz.define('Oskari.coordinatetransformation.instance',
                     return;
                 }
                 var state = event.getViewState();
-                if (state === 'attach') {
+                if (state === 'attach' && !this.flyoutAttached) { // hack, drag also fires attach
+                    this.flyoutAttached = true;
                     this.plugins['Oskari.userinterface.Flyout'].setContainerMaxHeight(Oskari.getSandbox().getMap().getHeight());
                     this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
                 } else if (state === 'restore') {
                     this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
-                } else if (state === 'close' || state === 'minimize') {
+                } else if (state === 'close') {
+                    this.flyoutAttached = false;
+                    this.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');
+                } else if (state === 'minimize') {
                     this.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');
                 }
             },

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/coordinatetransformation.css
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/coordinatetransformation.css
@@ -11,7 +11,9 @@
 .coordinatetransformation-flyout h5 {
     padding-bottom: 0px;
 }
-
+.coordinatetransformation-flyout .oskari-select .chosen-drop-up .chosen-results {
+    max-height: 200px;
+}
 /* Custom radio button */
 .coordinatetransformation-flyout input[type="radio"] {
     display: none;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -31,8 +31,8 @@ Oskari.registerLocalization(
                 },
                 "coordinateSystem":{
                     "label": "Coordinate system",
-                    "proj2D": "Projected 2D",
-                    "proj3D": "Projected 3D",
+                    "proj2D": "Cartesian 2D",
+                    "proj3D": "Cartesian 3D",
                     "geo2D": "Geographic 2D",
                     "geo3D": "Geographic 3D"
                 },
@@ -72,7 +72,7 @@ Oskari.registerLocalization(
                     "3DTo2D": "The selected input information contains height values, but the output information does not. Output coordinates will therefore not include height values. Do you want to continue?",
                     "2DTo3D": "The selected output information contains height values, but the input information does not. The height values 0 and height system N2000 will be added to the input information. Do you want to continue?",
                     "xyz": "No height system has been selected for the input coordinate system. It is not possible to transform this input information into a projected 3D system.",
-                    "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
+                    "largeFile": "The transformation of large files can take several minutes."
                 },
                 "validateErrors": {
                     "title": "Error!", // Error in coordinate system selections
@@ -81,30 +81,30 @@ Oskari.registerLocalization(
                     "noInputData": "No input coordinates.",
                     "noInputFile": "The file containing input information must be selected.",
                     "noFileName": "The output file must be named.",
-                    "decimalCount": "The decimal precision must be 0 or a positive integer.",
+                    "decimalCount": "The decimal number must be 0 or a positive integer.",
                     "headerCount": "The number of header rows must be 0 or a positive integer.",
                     "doubleComma": "The decimal and coordinate separators cannot both be commas.",
-                    "doubleSpace": "Kulman muoto/yksikkö ei voi sisältää välilyöntejä, jos koordinaattierotin on Välilyönti.",
+                    "doubleSpace": "The format/unit of an angle cannot contain spaces if the coordinate separator is Space.", //angle pattern
                     "noFileSettings": "No file settings.",
-                    "noCoordinateSeparator": "There must be a coordinate separator..",
-                    "noDecimalSeparator":"There must be a decimal separator."
+                    "noCoordinateSeparator": "Coordinate separator must be selected.",
+                    "noDecimalSeparator": "Decimal separator must be selected."
                 },
                 "responseErrors": {
                     "title": "Error in transformation!",
-                    "titleRead": "Virhe tiedoston lukemisessa!",
-                    "readFileError" : "Tiedostosta ei onnistuttu lukemaan kaikkia rivejä.",
-                    "transformFileError": "Tiedoston koordinaatteja ei onnistuttu muuntamaan.",
+                    "titleRead": "Error in reading file!",
+                    "readFileError" : "Not all rows of the file were read successfully.",
+                    "transformFileError": "The transformation of coordinates failed.",
                     "invalidLine": "The file's row {index, number} contains an invalid coordinate: {line}. Check that the selected decimal and coordinate separators and number of header rows match the contents of the file.",
-                    "generic": "Coordinate transformation failed...",
+                    "generic": "Coordinate transformation failed.",
                     //error codes
-                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
-                    "invalid_number": "Invalid coordinate.",
-                    "invalid_coord_in_array": "Invalid coordinate.",
+                    "invalid_coord": "Error in coordinate. Check that coordinates to be transformed are in correct format and that the geodetic coordinate reference system and height system are correct.",
+                    //"invalid_number": "Invalid coordinate.",
+                    //"invalid_coord_in_array": "Invalid coordinate.",
                     "no_coordinates": "No coordinates.",
                     "invalid_file_settings": "Error in file settings.",
                     "no_file": "No file matching the request could be found.",
                     "invalid_first_coord": "It was not possible to produce coordinates with these selections. Check that the coordinate separator, number of headers, geodetic coordinate and height system (dimension) selections as well as the option to use identifier or not match the contents of the file.",
-                    "transformation_error": "Koordinaattimuunnos epäonnistui. Koordinaattimuunnospalvelusta palautui virhe:"
+                    "transformation_error": "Coordinate transformation failed. Service responded with error:"
                 },
                 "responseFile": {
                     "title": "Attention!",
@@ -127,17 +127,17 @@ Oskari.registerLocalization(
             "map": {
                 "label": "Select locations on the map",
                 "info": "Select coordinates to be transformed on the map by clicking them.",
-                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN -projektion mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
+                "confirmSelect": "The input coordinate reference system is automatically changed to ETRS-TM35FIN. Your selections for the input coordinate reference system will be replaced. Do you want to continue?",
                 "action": "select more"
             }
         },
         "mapMarkers":{
             "show":{
                 "title": "Show locations on the map",
-                "info" : "The projection of the map is ETRS89-TM35FIN. Coordinates have been placed on the map using this coordinate reference system. With the location, the coordinates are shown numerically in the input and/or output coordinate reference system. ",
-                "errorTitle": "Virhe sijaintien näyttämisessä",
-                "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
-                "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
+                "info" : "The coordinate reference system of the map is ETRS-TM35FIN. Coordinates have been placed on the map using this coordinate reference system. With the location, the coordinates are shown numerically in the input and/or output coordinate reference system. ",
+                "errorTitle": "Error in showing positions",
+                "noCoordinates": "No coordinates available to be shown on the map",
+                "noSrs": "A geodetic coordinate reference system must be selected in input properties in order to show points on the map.",
                 "lon": "Lon",
                 "lat": "Lat",
                 "north": "N",
@@ -145,9 +145,9 @@ Oskari.registerLocalization(
             },
             "select":{
                 "title": "Select locations on the map",
-                "info": "Click to select one or more points on the map. The projection of the map is ETRS-TM35FIN. This coordinate reference system is automatically selected for the coordinates to be transformed and it cannot be changed. When selecting coordinates, please note that selecting locations on the map is not very precise.",
-                "add": "Add markers",
-                "remove": "Remove markers"
+                "info": "Click to select one or more points on the map. The coordinate reference system of the map is ETRS-TM35FIN. This coordinate reference system is automatically selected for the coordinates to be transformed and it cannot be changed. When selecting coordinates, please note that selecting locations on the map is not precise.",
+                "add": "Add points",
+                "remove": "Delete points"
             }
         },
         "actions": {
@@ -164,19 +164,20 @@ Oskari.registerLocalization(
                 "decimalSeparator": "Decimal separator",
                 "coordinateSeparator": "Coordinate separator",
                 "headerCount": "Number of header rows",
-                "decimalCount": "Decimal precision",
-                "reverseCoordinates": "Inverted coordinates", // Coordinates reversed
+                "decimalPrecision": "Decimal precision",
+                "reverseCoordinates": "Coordinates reversed",
                 "useId": { // Use identifier, Use id infront
-                    "input": "Coordinates include identifiers",
-                    "generate": "Generate identifiers",
-                    "fromFile": "Include identifiers from the input file"
+                    "input": "Coordinates contain identifiers",
+                    "generate": "Create identifers",
+                    "add": "Add identifiers",
+                    "fromFile": "Add input file identifiers"
                 },
                 "writeHeader": "Write header row into file",
                 "useCardinals": "Use cardinals (N,E,W,S)",
-                "lineEnds": "Include end-of-row markers in output", // Line ends to output
+                "lineEnds": "Add end-of-lines to output",
                 "choose": "Choose",
                 "degreeFormat":{
-                    "label": "Angle pattern", // Angle shape/unit
+                    "label": "Angle pattern", // Angle format/unit type/unit
                     "degree": "Degree",
                     "gradian": "Grade",
                     "radian": "Radian"
@@ -196,18 +197,38 @@ Oskari.registerLocalization(
                 }
             },
             "export": {
-                "title": "Formation of output information", // or file
+                "title": "Output properties",
                 "fileName": "File name"
             },
             "import": {
-                "title": "Formation of input information" // Input information properties
+                "title": "Input properties"
             }
         },
         "infoPopup": {
             "description": "Description",
+            "keyboard": {
+                "title": "Coordinate information source - table",
+                "paragraphs": [
+                    "Put the input information into the Input coordinates table."
+                ]
+            },
+            "map": {
+                "title": "Coordinate information source - map",
+                "paragraphs": [
+                    "Select coordinates to be transformed on the map by clicking them.",
+                    "The coordinate reference system of the map is ETRS-TM35FIN. This coordinate reference system is automatically selected for the coordinates to be transformed and it cannot be changed.",
+                    "When selecting coordinates, please note that selecting locations on the map is not precise."
+                ]
+            },
+            "file": {
+                "title": "Coordinate information source - file",
+                "paragraphs": [
+                    "Select the file containing the input information and its settings."
+                ]
+            },
             "epsgSearch": {
                 "title": "Search using EPSG code",
-                "info": "You can search for a geodetic coordinate reference system using the EPSG code. Input the code as a numerical value, such as 3067.",
+                "info": "A geodetic reference system may be searched with the EPSG code. Give the code as a numerical value, such as 3067.",
                 "listItems": []
             },
             "geodeticDatum": {
@@ -215,14 +236,14 @@ Oskari.registerLocalization(
                 "info": "Datum describing the relationship between a 2D or 3D coordinate system and the Earth.",
                 "listItems" : [
                     "Datum: a parameter or set of parameters defining the origin, scale and orientation of a coordinate system.",
-                    "Examples of a geodetic datum are EUREF-FIN and the KKJ coordinate reference system."
+                    "Examples of a geodetic datum are EUREF-FIN and the KKJ."
                 ]
             },
             "coordinateSystem":{
                 "title": "Coordinate system",
-                "info": "A set of mathematical rules defining how points are assigned coordinates.",
+                "info": "A set of mathematical rules defining how coordinates are assigned to points.",
                 "listItems" : [
-                    "Diferent types of coordinate systems include rectangular coordinate systems, projected coordinate systems, polar coordinate systems, geodetic coordinate systems, spherical coordinate systems and cylindrical coordinate systems."
+                    "Diferent types of coordinate systems include cartesian coordinate systems, projected coordinate systems, polar coordinate systems, geodetic coordinate systems, spherical coordinate systems and cylindrical coordinate systems."
                 ]
             },
             "mapProjection":{
@@ -230,14 +251,14 @@ Oskari.registerLocalization(
                 "info": "A set of rules determining how an area is described using a set of map projections.",
                 "listItems" : [
                     "Map projection: a method of describing a three-dimensional surface on a two-dimensional plane (map).",
-                    "The rules can be used to affirm map projections and projection zones. For projection zones the system can define identifiers, the scale, width, length and superimposition of central meridians or central parallels."
+                    "The rules can be used to define map projections and projection zones. Map projection system may define identifiers, scale factor at central meridian or parallel, width or lenght or overlapping of the projection zones."
                 ]
             },
             "geodeticCoordinateSystem":{
                 "title": "Geodetic coordinate reference system",
                 "info": "Coordinate reference system based on a geodetic datum.",
                 "listItems" : [
-                    "Coordinate reference system: a system consisting of a coordinate system that is tied to the real world with a datum.",
+                    "Coordinate reference system: a system consisting of a coordinate system that is related to the Earth with a datum.",
                     "The national projected coordinate system of Finland is ETRS-TM35FIN."
                 ]
             },
@@ -245,8 +266,8 @@ Oskari.registerLocalization(
                 "title":"Vertical coordinate reference system",
                 "info": "One-dimensional coordinate system based on a vertical datum.",
                 "listItems" : [
-                    "Vertical datum: a datum defining the relationship between heights or depths related to gravity and the Earth.",
-                    "In nationwide tasks in Finland, we use the N2000 height system that is compliant with the JHS 163 recommendation."
+                    "Vertical datum: a datum defining the relationship between gravity-related heights or depths and the Earth.",
+                    "N2000 height system, described in the JHS163 recommendation, is to be used for nationwide tasks in Finland. "
                 ]
             },
             "fileName":{
@@ -259,11 +280,11 @@ Oskari.registerLocalization(
                 "title":"Decimal precision",
                 "info": "Number of decimals included in the output",
                 "paragraphs": [
-                    "This property is used to define the decimal accuracy of coordinates in the output. The default on the form is the number of decimals matching an accuracy of 1mm. The default for showing degrees is the nearest number of decimals in the metric system matching an accuracy of 1mm."
+                    "This property is used to define the decimal accuracy of coordinates in the output. The default is the number of decimals matching an accuracy of 1mm." // The default for showing degrees is the nearest number of decimals in the metric system matching an accuracy of 1mm."
                 ],
                 "listItems" : [],
                 "precisionTable": {
-                    "title": "Kulman muodon/yksikön desimaalien määrä metrisenä tarkkuutena",
+                    "title": "Number of decimals of angle pattern in metric equivalent",
                     "unit": "Angle pattern", // Angle shape/unit
                     "deg": "Degree, Grade and DD",
                     "rad": "Radian",
@@ -275,7 +296,7 @@ Oskari.registerLocalization(
                 "title":"Coordinate separator",
                 "info": "Coordinate separator", // TODO
                 "paragraphs": [
-                    "This property is used to show the column separator in the input file that is used to separate coordinate values. The input data cannot contain more than one such separator character between two coordinate values.",
+                    "This property is used to show the column separator in the input file that is used to separate coordinate values. The input data cannot contain more than one such separator between two coordinate values.",
                     "If the coordinates are preceded by an identifier or followed by a character string, these must also be separated from the coordinates using the same separator."
                 ],
                 "listItems" : []
@@ -291,10 +312,10 @@ Oskari.registerLocalization(
             },
             "unitFormat":{
                 "title":"Angle pattern",
-                "info": "Unit of a geographic coordinate expressed in degrees",
+                "info": "Unit of a geodetic coordinates",
                 "paragraphs": [
                     "This property is used to define the format of angle values. Supported angle units: Degree, Grade and Radian",
-                    "Sexagesimal forms derived from the degree are also supported. If in these formats degrees, minutes of arc and seconds of arc are separated by a space (DD MM and DD MM SS), the space cannot be used as the coordinate separator."
+                    "Sexagesimal forms derived from the degree are also supported. In these formats, if degrees, minutes of arc and seconds of arc are separated by a space (DD MM and DD MM SS), the space cannot be used as the coordinate separator."
                 ],
                 "listItems" : []
             },
@@ -309,9 +330,9 @@ Oskari.registerLocalization(
             },
             "lineSeparator":{
                 "title":"Line separator",
-                "info": "Character used as row or line break in the file",
+                "info": "Character used as line break in the file",
                 "paragraphs": [
-                    "This property is used to define the character or character string used to separate rows/lines in the file. This character or character string is added to the end of each line or row in the file."
+                    "This property is used to define the character or character string used to separate lines in the file. This character or character string is added to the end of each line in the file."
                 ],
                 "listItems" : []
             },
@@ -322,16 +343,16 @@ Oskari.registerLocalization(
                     "This property is used to define that the coordinate values of each point are preceded on the same line by the point's identifier (ID)",
                     "The point identifier must be separated from the coordinate values using the same character string as that used as the coordinate value separator.",
                     "If the input file does not contain point identifiers or the points have been imported from a table or a map, the points are assigned identifiers starting from 1 and increasing by one integer for each point.",
-                    "The identifiers in the output file do not need to be numerical."
+                    "The identifiers in the input file do not need to be numerical."
                 ],
                 "listItems" : []
             },
             "reverseCoordinates":{
-                "title":"Inverted coordinates",
+                "title":"Reversed coordinates",
                 "info": "",
                 "paragraphs": [
-                    "This property is used to define whether the first two coordinate values of each point in the file are in reverse order in comparison with the order given in the description of the coordinate system.",
-                    "For example, koordinates in the KKJ coordinate system are by default arranged so that the N coordinate is followed by the E coordinate. If the reverse order is selected, the E coordinate must precede the N coordinate in the file."
+                    "This property is used to define whether the first two coordinate values of each point in the file are in reverse order in comparison with the order given in the description of the coordinate reference system.",
+                    "For example, coordinates in the KKJ coordinate reference system are by default given in North, East order. If the reverse order is selected, the East coordinate must precede the North coordinate in the file."
                 ],
                 "listItems" : []
             },
@@ -339,26 +360,28 @@ Oskari.registerLocalization(
                 "title":"Include header rows",
                 "info": "Include header rows in the output",
                 "paragraphs": [
-                    "This property is used to include metadata about coordinates in the header row. The name of the coordinate reference system is added to the header row.",
+                    "This property is used to include metadata about coordinates in the header row. The code of the coordinate reference system is added to the header row.",
                     "When transforming from one file into another, any header rows in the input file in addition to the coordinate reference system information are added to the output file."
                 ],
                 "listItems" : []
             },
             "lineEnds":{
                 "title":"Include end-of-row markers in output",
-                "info": "End-of-row characters and character strings are added to the output file",
+                "info": "End-of-lines are added to the output file",
                 "paragraphs": [
-                    "This property is used to include any end-of-row characters or character strings from the input file to the output file. All characters following the coordinate values of a point count as the end-of-row character string for that row. The end-of-row character or character string must be separated from the coordinate values using the same character as that used as the coordinate value separator.",
-                    "This property only has an effect on the transformation from one file to another."
+                    "This property is used to include any end-of-line characters or character strings from the input file to the output file. All characters following the coordinate values until the line break are counted as end-of-line. The end-of-line must be separated from the coordinate values using the same character as that used as the coordinate value separator.",
+                    "This property takes effect only in transformations from a file to another."
                 ],
                 "listItems" : []
             },
             "useCardinals":{
                 "title":"Use cardinals",
-                "info": "Coordinate values are followed by points of the compass (N, E, W or S).",
+                "info": "Coordinate values are followed by cardinal directions (N, E, W or S).",
                 "paragraphs": [
-                    "This property is used to include points of the compass after coordinate values in the output. The inverse point of the compass is added to negative values and the minus signs are removed from coordinate values. For example, the value of the E coordinate 325418 becomes 325418E and the value of the E coordinate -325418 becomes 325418W.",
-                    "Points of the compass are indicated by writing N, E, W or S after the coordinate value."
+                    "This property is used to include cardinal directions to the coordinate values in the output.",
+                    "Cardinal directions are indicated by N, E, W or S after the coordinate value.",
+                    "The opposite cardinal direction is added to negative values and the minus signs are removed from coordinate values.",
+                    "For example, the value of the East coordinate 325418 becomes 325418E and the value of the East coordinate -325418 becomes 325418W."
                 ],
                 "listItems" : []
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -81,8 +81,8 @@ Oskari.registerLocalization(
                     "noInputData": "Ei muunnettavia koordinaatteja.",
                     "noInputFile": "Lähtöaineiston sisältävä tiedosto pitää olla valittuna.",
                     "noFileName": "Muodostettavalle tiedostolle pitää antaa tiedostonimi.",
-                    "decimalCount": "Desimaalien tarkkuus pitää olla 0 tai positiivinen kokonaisluku.",
-                    "headerCount": "Otsakerivien määrä pitää olla 0 tai positiivinen kokonaisluku.",
+                    "decimalCount": "Desimaalien määrän pitää olla 0 tai positiivinen kokonaisluku.",
+                    "headerCount": "Otsakerivien määrän pitää olla 0 tai positiivinen kokonaisluku.",
                     "doubleComma": "Desimaali- ja koordinaattierotin eivät voi molemmat olla pilkkuja.",
                     "doubleSpace": "Kulman muoto/yksikkö ei voi sisältää välilyöntejä, jos koordinaattierotin on Välilyönti.",
                     "noFileSettings": "Tiedostoasetuksia ei ole annettu.",
@@ -94,16 +94,16 @@ Oskari.registerLocalization(
                     "titleRead": "Virhe tiedoston lukemisessa!",
                     "readFileError" : "Tiedostosta ei onnistuttu lukemaan kaikkia rivejä.",
                     "transformFileError": "Tiedoston koordinaatteja ei onnistuttu muuntamaan.",
-                    "invalidLine": "Tiedostossa on rivillä: {index, number} virheellinen koordinaattirivi: {line} <br> Tarkasta, että kyseinen rivi on kelvollinen ja vastaa -- valintoja.", //TODO
-                    "generic": "Koordinaattimuunnos epäonnistui...",
+                    "invalidLine": "Tiedostossa on rivillä: {index, number} virheellinen koordinaattirivi: {line} <br> Tarkasta, että kyseinen rivi on kelvollinen ja vastaa lähtöaineiston ominaisuuksien valintoja.",
+                    "generic": "Koordinaattimuunnos epäonnistui.",
                     //error codes
-                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
-                    "invalid_number": "Koordinaatti virheellinen.",
-                    "invalid_coord_in_array": "Koordinaatti virheellinen.",
+                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit ovat oikeassa muodossa sekä geodeettinen koordinaatti- ja korkeusjärjestelmä ovat oikein.",
+                    //"invalid_number": "Koordinaatti virheellinen.",
+                    //"invalid_coord_in_array": "Koordinaatti virheellinen.",
                     "no_coordinates": "Tiedostosta ei löytynyt koordinaatteja. Tarkasta tiedosto sekä asetettu otsakerivien määrä.",
                     "invalid_file_settings": "Tiedoston asetukset virheelliset.",
                     "no_file": "Lähetetystä pyynnöstä ei löytynyt tiedostoa.",
-                    "invalid_first_coord": "Tiedostosta ei saatu muodostettua koordinaattia annetuilla asetuksilla. Tarkasta, että koordinaattierotin, otsakerivien määrä, käytä tunnistetta sekä geoodeettinen koordinaatti- ja korkeusjärjestelmä (dimensio) -valinnat vastaavat tiedoston sisältöä.",
+                    "invalid_first_coord": "Tiedostosta ei saatu muodostettua koordinaattia annetuilla asetuksilla. Tarkasta, että koordinaattierotin, otsakerivien määrä, käytä tunnistetta sekä geodeettinen koordinaatti- ja korkeusjärjestelmä (dimensio) -valinnat vastaavat tiedoston sisältöä.",
                     "transformation_error": "Koordinaattimuunnos epäonnistui. Koordinaattimuunnospalvelusta palautui virhe:"
                 },
                 "responseFile": {
@@ -127,14 +127,14 @@ Oskari.registerLocalization(
             "map": {
                 "label": "Valitse sijainnit kartalta",
                 "info": "Voit valita muunnettavia koordinaatteja kartalta klikkaamalla.",
-                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN -projektion mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
+                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN-koordinaattijärjestelmän mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
                 "action": "valitse lisää"
             }
         },
         "mapMarkers":{
             "show":{
                 "title": "Näytä sijainnit kartalla",
-                "info": "Kartta on ETRS89-TM35FIN -projektiossa. Koordinaatit on sijoitettu kartalle kyseistä koordinaattijärjestelmää käyttäen. Sijaintimerkinnän yhteydessä näytään lähtö- ja/tai tuloskoordinaattijärjestelmän mukaiset koordinaatit lukemina. ",
+                "info": "Kartta on ETRS-TM35FIN-koordinaattijärjestelmässä. Koordinaatit on sijoitettu kartalle kyseistä koordinaattijärjestelmää käyttäen. Sijaintimerkinnän yhteydessä näytään lähtö- ja/tai tuloskoordinaattijärjestelmän mukaiset koordinaatit lukemina. ",
                 "errorTitle": "Virhe sijaintien näyttämisessä",
                 "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
                 "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
@@ -145,7 +145,7 @@ Oskari.registerLocalization(
             },
             "select":{
                 "title": "Valitse sijainnit kartalta",
-                "info": "Valitse yksi tai useampi piste kartalta klikkaamalla. Kartta on ETRS-TM35FIN-projektiossa. Tämä koordinaattijärjestelmä valitaan automaattisesti eikä sitä voi muutta. Valinnoissa on syytä huomioida, että kartalta sijaintien valinta ei ole kovin tarkkaa ja valitut koordinaatit pyöristetään kokonaisluvuiksi.",
+                "info": "Valitse yksi tai useampi piste kartalta klikkaamalla. Kartta on ETRS-TM35FIN-koordinaattijärjestelmässä. Tämä koordinaattijärjestelmä valitaan automaattisesti eikä sitä voi muutta. Valinnoissa on syytä huomioida, että kartalta sijaintien valinta ei ole tarkka ja valitut koordinaatit pyöristetään kokonaisluvuiksi.",
                 "add": "Lisää merkintöjä",
                 "remove": "Poista merkintöjä"
             }
@@ -167,9 +167,10 @@ Oskari.registerLocalization(
                 "decimalPrecision": "Desimaalien tarkkuus",
                 "reverseCoordinates": "Koordinaatit käänteisesti",
                 "useId": {
-                    "input": "Koordinaatit sisältää tunnisteet",
+                    "input": "Koordinaatit sisältävät tunnisteet",
                     "generate": "Luo tunnisteet",
-                    "fromFile": "Lisää tunnisteet"
+                    "add": "Lisää tunnisteet",
+                    "fromFile": "Lisää tunnisteet lähtötiedostosta"
                 },
                 "writeHeader": "Kirjoita otsakerivi tiedostoon",
                 "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
@@ -182,7 +183,7 @@ Oskari.registerLocalization(
                     "radian": "Radiaani"
                 },
                 "lineSeparator": {
-                    "label": "Rivin erotin",
+                    "label": "Rivierotin",
                     "win": "Windows / DOS",
                     "unix": "Unix",
                     "mac": "MacOS"
@@ -205,6 +206,26 @@ Oskari.registerLocalization(
         },
         "infoPopup": {
             "description": "Kuvaus",
+            "keyboard": {
+                "title": "Koordinaattitietojen lähde - taulukko",
+                "paragraphs": [
+                    "Syötä lähtötiedot Muunnettavat koordinaatit -taulukkoon."
+                ]
+            },
+            "map": {
+                "title": "Koordinaattitietojen lähde - kartta",
+                "paragraphs": [
+                    "Voit valita muunnettavia koordinaatteja kartalta klikkaamalla.",
+                    "Kartta on ETRS-TM35FIN-koordinaattijärjestelmässä. Tämä koordinaattijärjestelmä valitaan automaattisesti eikä sitä voi muutta.",
+                    "Valinnoissa on syytä huomioida, että kartalta sijaintien valinta ei ole tarkkaa ja valitut koordinaatit pyöristetään kokonaisluvuiksi."
+                ]
+            },
+            "file": {
+                "title": "Koordinaattitietojen lähde - tiedosto",
+                "paragraphs": [
+                    "Valitse lähtöaineiston sisältävä tiedosto ja sen asetukset."
+                ]
+            },
             "epsgSearch": {
                 "title": "Haku EPSG-koodin perusteella",
                 "info": "Voit hakea geodeettisen koordinaattijärjestelmän EPSG-koodin avulla. Syötä koodi pelkkänä numerona esim. 3067.",
@@ -259,7 +280,7 @@ Oskari.registerLocalization(
                 "title":"Desimaalien tarkkuus",
                 "info": "Tulokseen tulevien desimaalien määrä",
                 "paragraphs": [
-                    "Ominaisuuden avulla kerrotaan ohjelmalle millä tarkkuudella koordinaatit halutaan tulokseen. Oletusarvona lomakkeella on 1mm tarkkuutta vastaava desimaalimäärä. Asteen esitysmuodoille oletusarvo on metristä järjestelmää vastaava lähin desimaalimäärä 1mm tarkkuuteen."
+                    "Ominaisuuden avulla kerrotaan ohjelmalle millä tarkkuudella koordinaatit halutaan tulokseen. Oletusarvona on 1mm tarkkuutta vastaava desimaalimäärä." // Asteen esitysmuodoille oletusarvo on metristä järjestelmää vastaava lähin desimaalimäärä 1mm tarkkuuteen."
                 ],
                 "listItems": [],
                 "precisionTable": {
@@ -291,7 +312,7 @@ Oskari.registerLocalization(
             },
             "unitFormat":{
                 "title":"Kulman muoto/yksikkö",
-                "info": "Maantieteellisen astemuotoisen koordinaatin yksikkö",
+                "info": "Geodeettisten koordinaattien yksikkö",
                 "paragraphs": [
                     "Ominaisuuden avulla kerrotaan ohjelmalle missä muodossa kulma-arvot ovat. Tuettuja kulmayksikköjä ovat: Aste, Gooni (graadi) ja Radiaani.",
                     "Lisäksi asteesta johdetut sexagesimaalimuodot ovat tuettuja. Jos näissä muodoissa esimerkiksi asteet, kaariminuutit ja kaarisekunnit ovat erotettuina, hyväksyy ohjelma erottimena tabulaattorin, pilkun ja puolipisteen, mutta ei välilyöntiä."
@@ -302,7 +323,7 @@ Oskari.registerLocalization(
                 "title":"Desimaalierotin",
                 "info": "Desimaaliosan erottamiseen käytetty merkki",
                 "paragraphs": [
-                    "Ominaisuuden avulla pystyy kertomaan mikä merkki toimii desimaalierotin.", //TODO
+                    "Ominaisuuden avulla pystyy kertomaan mikä merkki toimii desimaalierotimena.",
                     "Desimaalierottimen tulee poiketa koordinaattiarvot erottavasta merkistä. Kun koordinaattiarvot erottaa esimerkiksi pilkku sekä joukko välilyöntejä, niin desimaalierottimen on oltava piste."
                 ],
                 "listItems" : []
@@ -321,14 +342,14 @@ Oskari.registerLocalization(
                 "paragraphs": [
                     "Ominaisuuden avulla pystyy ohjelmalle kertomaan, että jokaisen pisteen koordinaattiarvoja edeltää samalla rivillä pisteen tunniste (ID).",
                     "Pisteen tunnisteen tulee olla erotettuna koordinaattiarvoista samalla merkkijonolla kuin koordinaattiarvot ovat erotettuina toisistaan.",
-                    "Jos tuodussa tiedostossa ei ole pisteiden tunnisteita tai pisteet on tuotu taulukosta tai kartalta, niin tulostiedoston pisteiden tunnisteiksi luodaan yhdellä arvolla kasvava kokonaisluku alkaen arvosta 1.",
+                    "Jos tuodussa tiedostossa ei ole pisteiden tunnisteita tai pisteet on tuotu taulukosta tai kartalta, niin tulostiedoston pisteiden tunnisteiksi luodaan yhdellä kasvava kokonaisluku alkaen arvosta 1.",
                     "Tunnisteen ei tarvitse olla numeerinen."
                 ],
                 "listItems" : []
             },
             "reverseCoordinates":{
                 "title":"Koordinaatit käänteisesti",
-                "info": "X- ja Y-Koordinaattiakselien järjestys poikkeaa määritetystä järjestyksestä",
+                "info": "X- ja Y-koordinaattiakselien järjestys poikkeaa määritetystä järjestyksestä",
                 "paragraphs": [
                     "Ominaisuuden avulla pystyy määrittämään ovatko tiedoston pisteiden kaksi ensimmäistä koordinaattiarvoa käänteisessä järjestyksessä suhteessa koordinaatiston kuvailussa annettuun järjestykseen.",
                     "Esimerkiksi kkj:n koordinaatit ovat lähtökohtaisesti järjestyksessä, jossa ensimmäisenä on x-koordinaatti ja sitä seuraa y-koordinaatti. x-akseli osoittaa pohjoiseen ja y-akseli itään. Kun valitsee käänteisen järjestyksen, tulee tiedostossa y-koordinaatin edeltää x-koordinaattia."
@@ -357,8 +378,10 @@ Oskari.registerLocalization(
                 "title":"Kardinaalien käyttö",
                 "info": "Koordinaattiarvojen perään lisätään ilmansuunnat (N, E, W tai S)",
                 "paragraphs": [
-                    "Ominaisuudella määritetään kirjoitetaanko tulosteeseen koordinaattiarvojen perään niiden ilmansuunnat. Tällöin miinusmerkit poistetaan koordinaattiarvoista.",
-                    "Ilmansuunnat annetaan kirjoittamalla joko N, E, W tai S koordinaattiarvon perään."
+                    "Ominaisuudella määritetään kirjoitetaanko tulosteeseen koordinaattiarvojen perään niiden ilmansuunnat.",
+                    "Ilmansuunnat annetaan kirjoittamalla joko N, E, W tai S koordinaattiarvon perään.",
+                    "Miinusmerkkisille arvoille lisätään vastailmansuunta, jolloin miinusmerkit poistetaan koordinaattiarvoista.",
+                    "Esimerkiksi itäkoordinaatin 325418 arvoksi tulee 325418E ja itäkoordinaatin -325418 arvoksi tulee 325418W."
                 ],
                 "listItems" : []
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -104,7 +104,7 @@ Oskari.registerLocalization(
                     "invalid_file_settings": "Felaktiga filinställningar.",
                     "no_file": "Det fanns ingen fil för begäran.",
                     "invalid_first_coord": "Det var inte möjligt att bilda en koordinat med de angivna inställningarna. Kontrollera att valen av skiljetecken för koordinater, antalet rubrikrader, huruvida identifierare används eller inte samt geodetiska referenssystem för koordinater och höjdsystem (dimension) motsvarar filens innehåll.",
-                    "transformation_error": "Koordinatomvandlingen misslyckades. Koordinaattimuunnospalvelusta palautui virhe:"
+                    "transformation_error": "Koordinatomvandlingen misslyckades. Koordinattransformation service respons:" //TODO
                 },
                 "responseFile": {
                     "title": "Observera!",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -3,12 +3,12 @@ Oskari.registerLocalization(
     "lang": "sv",
     "key": "coordinatetransformation",
     "value": {
-        "title": "Koordinatomvandling",
+        "title": "Koordinattransformation",
         "tile": {
-            "title": "Koordinatomvandling"
+            "title": "Koordinat- transformation"
         },
         "flyout": {
-            "title":"Koordinatomvandling",
+            "title":"Koordinattransformation",
             "filterSystems": {
                 "title": "Filtrera referenssystem för koordinater",
                 "epsg": "Med EPSG-kod",
@@ -31,8 +31,8 @@ Oskari.registerLocalization(
                 },
                 "coordinateSystem":{
                     "label": "Koordinatsystem",
-                    "proj2D": "Projicerat 2D (Plan)",
-                    "proj3D": "Projicerat 3D",
+                    "proj2D": "Kartesiskt 2D (Plan)",
+                    "proj3D": "Kartesiskt 3D",
                     "geo2D": "Geografiskt 2D",
                     "geo3D": "Geografiskt 3D"
                 },
@@ -41,7 +41,7 @@ Oskari.registerLocalization(
                 },
                 "geodeticCoordinateSystem":{
                     "label": "Geodetiskt referenssystem för koordinater", // Geodetiskt koordinatsystem
-                    "choose": "Valitse",
+                    "choose": "Välj",
                     "kkj": "KKS zon {zone, number}",
                     "ykj": "KKS zon 3 / EKS"
                 },
@@ -51,7 +51,7 @@ Oskari.registerLocalization(
                 }
             },
             "coordinateTable": {
-                "input": "Koordinater som ska omvandlas",
+                "input": "Koordinater som ska transformeras",
                 "output": "Resultatkoordinater",
                 "north":"Nord-koordinat [m]",
                 "east":"Öst-koordinat [m]",
@@ -71,50 +71,50 @@ Oskari.registerLocalization(
                     "title": "Observera!",
                     "3DTo2D": "I de utgångsuppgifter du valt finns höjdvärden, men inte i resultatuppgifterna. Höjvärden ingår alltså inte i resultatkoordinaterna. Vill du fortsätta?",
                     "2DTo3D": "I de resultatuppgifter du valt finns höjdvärden, men inte i utgångsuppgifterna. Utgångsmaterialet ges höjdvärdet 0 och höjdsystemet N2000. Vill du fortsätta?",
-                    "xyz": "I valen som berör utgångsreferenssystemet för koordinater finns inget höjdsystem. En omvandling till ett rätvinkligt 3D-system kan inte göras.",
-                    "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
+                    "xyz": "I valen som berör utgångsreferenssystemet för koordinater finns inget höjdsystem. En omvandling till ett kartesiskt 3D-system kan inte göras.",
+                    "largeFile": "Transformation av stora filer kan ta flera minuter."
                 },
                 "validateErrors": {
                     "title": "Fel!",
                     "message": "Det finns brister eller fel i valen. Beakta följande krav och försök på nytt.",
                     "crs": "Ett geodetiskt referenssystem för koordinater ska vara valt både i utgångs- och resultatuppgifterna.",
-                    "noInputData": "Det finns inga koordinater som kan omvandlas.",
+                    "noInputData": "Det finns inga koordinater som kan transformeras.",
                     "noInputFile": "Filen som innehåller utgångsmaterial ska vara vald.",
                     "noFileName": "Filen som bildas ska ges ett filnamn.",
-                    "decimalCount": "Decimalernas noggrannhet ska vara 0 eller ett positivt heltal.",
+                    "decimalCount": "Decimalernas antalet ska vara 0 eller ett positivt heltal.",
                     "headerCount": "Antalet rubrikrader ska vara 0 eller ett positivt heltal.",
                     "doubleComma": "Skiljetecknen för decimaler och koordinater kan inte båda vara kommatecken.",
-                    "doubleSpace": "Kulman muoto/yksikkö ei voi sisältää välilyöntejä, jos koordinaattierotin on Välilyönti.",
+                    "doubleSpace": "Vinkelns form/enhet kan inte innehålla mellanslag, om koordinatskiljetecknet är Mellanslag.",
                     "noFileSettings": "Inga filinställningar har angetts..",
                     "noCoordinateSeparator": "Skiljetecknet för koordinater ska vara valt.",
                     "noDecimalSeparator": "Skiljetecknet för decimaler ska vara valt."
                 },
                 "responseErrors": {
-                    "titleTransform": "Fel i omvandlingen!",
-                    "titleRead": "Virhe tiedoston lukemisessa!",
-                    "readFileError" : "Tiedostosta ei onnistuttu lukemaan kaikkia rivejä.",
-                    "transformFileError": "Tiedoston koordinaatteja ei onnistuttu muuntamaan.",
+                    "titleTransform": "Fel i transformation!",
+                    "titleRead": "Fel i inläsningen av filen!",
+                    "readFileError" : "Inläsningen av alla rader i filen lyckades inte.",
+                    "transformFileError": "Transformationen av koordinater i filen lyckades inte.",
                     "invalidLine": "I filen finns på rad: {index, number} felaktig koordinatrad: {line} Kontrollera att valen av skiljetecknen för decimaler och koordinater samt antalet rubrikrader motsvarar filens innehåll.",
-                    "generic": "Koordinatomvandlingen misslyckades...",
+                    "generic": "Koordinattransformationen misslyckades.",
                     //error codes
-                    "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit on oikeassa muodossa sekä geodeettinen koordinaatti- ja kokeusjärjestelmä ovat oikein.",
-                    "invalid_number": "Koordinaatti virheellinen. Tarkasta..",
-                    "invalid_coord_in_array": "Koordinaatti virheellinen. Tarkasta..",
-                    "no_coordinates": "Ei koordinaatteja",
+                    "invalid_coord": "Fel i koordinaten. Kontrollera att koordinaterna som ska omvandlas är i rätt format och att de geodetiska referenssystemen för koordinater och höjder är korrekta.",
+                    //"invalid_number": "",
+                    //"invalid_coord_in_array": "",
+                    "no_coordinates": "Inga koordinater",
                     "invalid_file_settings": "Felaktiga filinställningar.",
                     "no_file": "Det fanns ingen fil för begäran.",
                     "invalid_first_coord": "Det var inte möjligt att bilda en koordinat med de angivna inställningarna. Kontrollera att valen av skiljetecken för koordinater, antalet rubrikrader, huruvida identifierare används eller inte samt geodetiska referenssystem för koordinater och höjdsystem (dimension) motsvarar filens innehåll.",
-                    "transformation_error": "Koordinaattimuunnos epäonnistui. Koordinaattimuunnospalvelusta palautui virhe:"
+                    "transformation_error": "Koordinatomvandlingen misslyckades. Koordinaattimuunnospalvelusta palautui virhe:"
                 },
                 "responseFile": {
                     "title": "Observera!",
-                    "hasMoreCoordinates": "Det är inte möjligt att från utgångsmaterialet omvandla fler än {maxCoordsToArray, number} koordinater i tabellen. Om du vill omvandla alla koordinater, använd funktionen För in resultaten i en fil."
+                    "hasMoreCoordinates": "Det är inte möjligt att från utgångsmaterialet transformera fler än {maxCoordsToArray, number} koordinater i tabellen. Om du vill transformera alla koordinater, använd funktionen För in resultaten i en fil."
                 }
             }
         },
         "dataSource": {
             "title": "Källa för koordinatuppgifter",
-            "confirmChange": "Koordinaterna som ska omvandlas töms. Vill du fortsätta?",
+            "confirmChange": "Koordinaterna som ska transformeras töms. Vill du fortsätta?",
             "file": {
                 "label": "Från fil",
                 "info":  "Välj filen med utgångsmaterialet och dess inställningar.",
@@ -122,22 +122,22 @@ Oskari.registerLocalization(
             },
             "keyboard": {
                 "label": "Med tangentbordet",
-                "info": "Mata in utgångsuppgifter i tabellen Koordinater som ska omvandlas."
+                "info": "Mata in utgångsuppgifter i tabellen Koordinater som ska transformeras."
             },
             "map": {
                 "label": "Välj lägen på kartan",
-                "info": "Du kan välja koordinater som ska omvandlas genom att klicka på kartan",
-                "confirmSelect": "Lähtökoordinaattijärjestelmän tiedot valitaan automaattisesti kartan käyttämän ETRS-TM35FIN -projektion mukaisiksi. Tekemäsi lähtökoordinaattijärjestelmän valinnat korvataan. Haluatko jatkaa?",
+                "info": "Du kan välja koordinater som ska transformeras genom att klicka på kartan",
+                "confirmSelect": "Uppgifterna om utgångsreferenssystemet för koordinater väljs automatiskt att vara i ETRS-TM35FIN. Dina val av utgångsreferenssystem för koordinater ersätts. Vill du fortsätta?",
                 "action": "välj fler"
             }
         },
         "mapMarkers":{
             "show":{
                 "title": "Visa lägen på kartan",
-                "info" : "Kartans projektion är ETRS-TM35FIN. Koordinaterna har placerats på kartan med hjälp av detta referenssystem för koordinater. I samband med lägesanteckningen anges koordinaterna enligt utgångs- och/eller resultatreferenssystemet i siffror.",
-                "errorTitle": "Virhe sijaintien näyttämisessä",
-                "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
-                "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
+                "info" : "Kartans referenssystem för koordinater är ETRS-TM35FIN. Koordinaterna har placerats på kartan med hjälp av detta referenssystem för koordinater. I samband med lägesanteckningen anges koordinaterna enligt utgångs- och/eller resultatreferenssystemet i siffror.",
+                "errorTitle": "Fel i visningen av positioner",
+                "noCoordinates": "Det finns inga koordinater att visa på kartan.",
+                "noSrs": "Ett geodetiskt referenssystem för koordinater måste ingå i utgångsuppgifterna för att kunna visa punkter på kartan.",
                 "lon": "Lon",
                 "lat": "Lat",
                 "north": "N",
@@ -145,14 +145,14 @@ Oskari.registerLocalization(
             },
             "select":{
                 "title": "Välj lägen på kartan",
-                "info": "Välj en eller flera punkter på kartan genom att klicka på dem. Kartans projektion är ETRS-TM35FIN. Detta referenssystem för koordinater väljs automatiskt för de koordinater som omvandlas och kan inte ändras. Beakta vid val av koordinater att valet av läge inte är exakt.",
-                "add": "Lisää merkintöjä",
-                "remove": "Poista merkintöjä"
+                "info": "Välj en eller flera punkter på kartan genom att klicka på dem. Kartans referenssystem för koordinater är ETRS-TM35FIN. Detta referenssystem för koordinater väljs automatiskt för de koordinater som omvandlas och kan inte ändras. Beakta vid val av koordinater att valet av läge inte är exakt.",
+                "add": "Lägg till punkter",
+                "remove": "Ta bort punkter"
             }
         },
         "actions": {
-            "convert": "Omvandla", //Transformera
-            "export": "Omvandla i en fil",
+            "convert": "Transformera", //Transformera
+            "export": "Transformera i en fil",
             "select": "Välj",
             "cancel": "Avbryt", //Ångra
             "done": "Färdig",
@@ -167,9 +167,10 @@ Oskari.registerLocalization(
                 "decimalCount": "Decimalernas precision",
                 "reverseCoordinates": "Omvända koordinater",
                 "useId": { // Använd identifierare
-                    "input": "Koordinaatit sisältää tunnisteet",
-                    "generate": "Luo tunnisteet",
-                    "fromFile": "Lisää lähtötiedoston tunnisteet"
+                    "input": "Koordinater innehåller identiferare",
+                    "generate": "Skapa identifierare",
+                    "add": "Lägg till identifierare",
+                    "fromFile": "Lägg till utgångsfilens identifierare"
                 },
                 "writeHeader": "Skriv rubrikraden i filen",
                 "useCardinals": "Använd kardinalväderstreck (N,E,W,S)",
@@ -205,6 +206,26 @@ Oskari.registerLocalization(
         },
         "infoPopup": {
             "description": "Beskrivning",
+            "keyboard": {
+                "title": "Källa för koordinatuppgifter - tabell",
+                "paragraphs": [
+                    "Mata in utgångsuppgifter i tabellen Koordinater som ska omvandlas."
+                ]
+            },
+            "map": {
+                "title": "Källa för koordinatuppgifter - kartan",
+                "paragraphs": [
+                    "Du kan välja koordinater som ska omvandlas genom att klicka på kartan",
+                    "Kartans  referenssystem för koordinater är ETRS-TM35FIN. Detta referenssystem för koordinater väljs automatiskt för de koordinater som omvandlas och kan inte ändras.",
+                    "Beakta vid val av koordinater att valet av läge inte är exakt."
+                ]
+            },
+            "file": {
+                "title": "Källa för koordinatuppgifter - fil",
+                "paragraphs": [
+                    "Välj filen med utgångsmaterialet och dess inställningar."
+                ]
+            },
             "epsgSearch": {
                 "title": "Sök med EPSG-kod",
                 "info": "Du kan söka ett geodetiskt referenssystem för koordinater med EPSG-kod. Mata in koden enbart i sifferform, t.ex. 3067.",
@@ -222,7 +243,7 @@ Oskari.registerLocalization(
                 "title": "Koordinatsystem",
                 "info": "En mängd matematiska regler som bestämmer hur koordinater för punkter definieras.",
                 "listItems" : [
-                    "Olika typer av koordinatsystem är bl.a. rätvinkligt koordinatsystem, plankoordinatsystem, polärt koordinatsystem, geodetiskt koordinatsystem, sfäriskt koordinatsystem och cylindriskt koordinatsystem."
+                    "Olika typer av koordinatsystem är bl.a. kartesiskt koordinatsystem, plankoordinatsystem, polärt koordinatsystem, geodetiskt koordinatsystem, sfäriskt koordinatsystem och cylindriskt koordinatsystem."
                 ]
             },
             "mapProjection":{
@@ -238,12 +259,12 @@ Oskari.registerLocalization(
                 "info": "Ett referenssystem för koordinater som baserar sig på ett geodetiskt datum.",
                 "listItems" : [
                     "Referenssystem för koordinater: ett koordinatsystem som har bundits till den verkliga världen med hjälp av ett datum.",
-                    "Finlands riksomfattande projicerade koordinatsystem är ETRS-TM35FIN."
+                    "Finlands riksomfattande projicerade referenssystem för koordinater är ETRS-TM35FIN."
                 ]
             },
             "heightSystem":{
                 "title":"Höjdsystem",
-                "info": "Ett endimensionerat koordinatsystem som baserar sig på ett höjddatum.",
+                "info": "Ett endimensionerat referenssystem för koordinater som baserar sig på ett höjddatum.",
                 "listItems" : [
                     "Höjddatum: datum som definierar förhållandet mellan höjder och djup i anslutning till tyngdkraften och Jorden.",
                     "I Finland används höjdsystemet N2000 som är förenlig med rekommendationen JHS 163 i riksomfattande arbeten."
@@ -259,11 +280,11 @@ Oskari.registerLocalization(
                 "title":"Decimalernas precision",
                 "info": "Antalet decimaler som visas i resultatet.",
                 "paragraphs": [
-                    "Med denna egenskap kan man ange med hur många decimalers noggrannhet koordinaterna visas i resultatet. Det förvalda värdet på blanketten motsvarar ett antal decimaler som ger en 1 mm precision. Det förvalda värdet för gradangivelser är det närmaste antalet decimaler som i det metriska sytemet motsvarar 1 mm."
+                    "Med denna egenskap kan man ange med hur många decimalers noggrannhet koordinaterna visas i resultatet. Det förvalda värdet motsvarar ett antal decimaler som ger en 1 mm precision." // Det förvalda värdet för gradangivelser är det närmaste antalet decimaler som i det metriska sytemet motsvarar 1 mm."
                 ],
                 "listItems" : [],
                 "precisionTable": {
-                    "title": "Kulman muodon/yksikön desimaalien määrä metrisenä tarkkuutena",
+                    "title": "Antalet decimaler av vinkels form/enhet i metrisk ekvivalent",
                     "unit": "Vinkelns form/enhet",
                     "deg": "Grad, gon och DD",
                     "rad": "Radian",
@@ -291,7 +312,7 @@ Oskari.registerLocalization(
             },
             "unitFormat":{
                 "title":"Vinkelns form/enhet",
-                "info": "Enhet för geografiska koordinater i gradformat",
+                "info": "Enhet för geodetiska koordinater",
                 "paragraphs": [
                     "Med denna egenskap anges formatet för gradvärden. Gradenheter som applikationen stöder: Grad, Gon (nygrad) och Radian.",
                     "Dessutom stöds sexagesimalformat som härletts ur grader. Om man i dessa format har avskiljt grader, bågminuter och bågsekunder med mellanslag (DD MM och DD MM SS), kan mellanslaget inte användas som skiljetecken för koordinater."
@@ -348,7 +369,7 @@ Oskari.registerLocalization(
                 "info": "Inkludera radsluten i utgångsfilen i resultatfilen",
                 "paragraphs": [
                     "Med denna egenskap kan man ange om man vill ha eventuella radslut i utgångsfilen i resultatfilen. Som radslut läser applikationen in alla tecken efter punktens koordinatvärden på raden. Radslutet ska vara avskilt från koordinatvärdena med samma tecken som skiljer koordinatvärdena från varandra.",
-                    "Denna egenskap påverkar endast omvandlingar från en fil till en annan."
+                    "Denna egenskap påverkar endast transformationer från en fil till en annan."
                     
                 ],
                 "listItems" : []
@@ -357,8 +378,10 @@ Oskari.registerLocalization(
                 "title":"Använd kardinalväderstreck",
                 "info": "Lägg till väderstrecken (N, E, W eller S) efter koordinatvärdena",
                 "paragraphs": [
-                    "Med denna egenskap anges om koordinatvärdenas väderstreck skrivs ut efter koordinatvärdena i en utskrift. På värden med förtecknet minus läggs det motsatta väderstrecket till och minustecknen tas bort från koordinatvärdena. Exempel: värdet på östkoordinaten 325418 blir 325418E och på östkoordinaten -325418 blir värdet 325418W.",
-                    "Väderstrecken anges genom att skriva N, E, W eller S efter respektive koordinatvärde."
+                    "Med denna egenskap anges om koordinatvärdenas väderstreck skrivs ut efter koordinatvärdena i en utskrift.",
+                    "Väderstrecken anges genom att skriva N, E, W eller S efter respektive koordinatvärde.",
+                    "På värden med förtecknet minus läggs det motsatta väderstrecket till och minustecknen tas bort från koordinatvärdena.",
+                    "Exempel: värdet på östkoordinaten 325418 blir 325418E och på östkoordinaten -325418 blir värdet 325418W."
                 ],
                 "listItems" : []
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/util/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/util/helper.js
@@ -271,7 +271,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.helper', function () {
                 };
                 if (compound.reversed) {
                     compoundValues.isAxisFlip = true;
-                    compoundValues.reversed = compound.reversed;
+                    compoundValues.replaced = compound.reversed;
                 }
                 return compoundValues;
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -266,7 +266,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
             if (this.type === 'export') {
                 var lineEnds = elem.find('.lineEnds');
                 if (this.isFileInput) {
-                    useId.text(this.loc('fileSettings.options.useId.fromFile'));
+                    useId.text(this.loc('fileSettings.options.useId.add'));
                     lineEnds.css('display', '');
                 } else {
                     useId.text(this.loc('fileSettings.options.useId.generate'));

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -509,7 +509,6 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             }
         },
         transformToMapCoords: function (callback) {
-            this.showSpinner(true);
             var crsSettings = {
                 sourceCrs: this.inputSystem.getSrs(),
                 sourceDimension: this.instance.getDimensions().input,
@@ -520,14 +519,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             if (this.sourceSelect.getSourceSelection() === 'file') {
                 var fileSettings = this.importFileHandler.getSettings();
                 if (this.helper.validateFileSelections(fileSettings)) {
+                    this.showSpinner(true);
                     this.instance.getService().transformFileToArray(crsSettings, fileSettings, callback, this.handleErrorResponse.bind(this));
                 }
             } else {
+                this.showSpinner(true);
                 this.instance.getService().transformArrayToArray(this.dataHandler.getInputCoords(), crsSettings, callback, this.handleErrorResponse.bind(this));
             }
         },
         transformToTable: function () {
-            this.showSpinner(true);
             var crsSettings = this.getCrsOptions();
             var source = this.sourceSelect.getSourceSelection();
             var coords;
@@ -535,11 +535,13 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             if (source === 'file') {
                 fileSettings = this.importFileHandler.getSettings();
                 if (this.helper.validateFileSelections(fileSettings)) {
+                    this.showSpinner(true);
                     this.instance.getService().transformFileToArray(crsSettings, fileSettings, this.handleArrayResponse.bind(this), this.handleErrorResponse.bind(this));
                 }
             } else {
                 if (this.dataHandler.hasInputCoords()) {
                     coords = this.dataHandler.getInputCoords();
+                    this.showSpinner(true);
                     this.instance.getService().transformArrayToArray(coords, crsSettings, this.handleArrayResponse.bind(this), this.handleErrorResponse.bind(this));
                 } else {
                     this.showMessage(this.loc('flyout.transform.validateErrors.title'), this.loc('flyout.transform.validateErrors.noInputData'));
@@ -547,7 +549,6 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             }
         },
         transformToFile: function (settings) {
-            this.showSpinner(true);
             var crsSettings = this.getCrsOptions();
             var exportSettings = settings;
             var coords;
@@ -556,13 +557,15 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                 var importSettings = this.importFileHandler.getSettings();
                 if (this.helper.validateFileSelections(importSettings)) {
                     if (importSettings.file.size > 5 * 1024 * 1024) {
-                        this.showMessage(this.loc('flyout.transform.warning.title'), this.loc('flyout.transform.warning.largeFile'));
+                        this.showMessage(this.loc('flyout.transform.warnings.title'), this.loc('flyout.transform.warnings.largeFile'));
                     }
+                    this.showSpinner(true);
                     this.instance.getService().transformFileToFile(crsSettings, importSettings, exportSettings, this.handleFileResponse.bind(this), this.handleErrorResponse.bind(this));
                 }
             } else {
                 if (this.dataHandler.hasInputCoords()) {
                     coords = this.dataHandler.getInputCoords();
+                    this.showSpinner(true);
                     this.instance.getService().transformArrayToFile(coords, crsSettings, exportSettings, this.handleFileResponse.bind(this), this.handleErrorResponse.bind(this));
                 } else {
                     this.showMessage(this.loc('flyout.transform.validateErrors.title'), this.loc('flyout.transform.validateErrors.noInputData'));

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -510,7 +510,8 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
         },
         transformToMapCoords: function (callback) {
             var crsSettings = {
-                sourceCrs: this.inputSystem.getSrs(),
+                sourceCrs: this.inputSystem.getSrsForTransformation(),
+                sourceElevationCrs: this.inputSystem.getElevation(),
                 sourceDimension: this.instance.getDimensions().input,
                 targetCrs: this.helper.mapSrs,
                 targetDimension: 2

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -556,7 +556,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             if (source === 'file') {
                 var importSettings = this.importFileHandler.getSettings();
                 if (this.helper.validateFileSelections(importSettings)) {
-                    if (importSettings.file.size > 5 * 1024 * 1024) {
+                    if (importSettings.file.size > 10 * 1024 * 1024) {
                         this.showMessage(this.loc('flyout.transform.warnings.title'), this.loc('flyout.transform.warnings.largeFile'));
                     }
                     this.showSpinner(true);

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -330,7 +330,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             } else if (value === 'map') {
                 this.inputTable.setIsEditable(false);
                 this.selectFromMap();
-                this.inputSystem.selectMapProjection(this.filter === 'epsg');
+                this.inputSystem.selectMapProjection(this.filter === 'systems');
                 this.inputSystem.disableAllSelections(true);
                 this.exportFileHandler.setIsFileInput(false);
                 this.bindInputTableHandler(false);


### PR DESCRIPTION
Bug fixes:
- start spinner only when request is sent
- set flyout container max height and top on attach (on start plugin can't calculate content height)
- update input table and input coords on system selection change (fix issue 2d <-> 3d)
- replace epsg-code to transform if hidden epsg is used (from epsg search)

Add info popups also to source selections because other info icons opens popup.
Update localization files