### PR TITLE
Fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "eslint": "^4.6.1",
     "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "2.13.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1"


### PR DESCRIPTION
Locking down eslint-plugin-import as there's something funky going on in the registry regarding the eslint versions thats preventing clean installs.