### PR TITLE
Add wfsmvt to main.js

### DIFF
--- a/applications/paikkatietoikkuna.fi/full-map/main.js
+++ b/applications/paikkatietoikkuna.fi/full-map/main.js
@@ -5,6 +5,7 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol3/maparcgis/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapmodule/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/oskariui/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapwfs2/bundle.js';
+import 'oskari-loader!oskari-frontend/packages/mapping/ol3/wfsmvt/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapuserlayers/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/ui-components/bundle.js';
 import 'oskari-loader!oskari-frontend-contrib/packages/mapping/ol/mapanalysis/bundle.js';

--- a/applications/paikkatietoikkuna.fi/full-map_experimental/main.js
+++ b/applications/paikkatietoikkuna.fi/full-map_experimental/main.js
@@ -5,6 +5,7 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol3/maparcgis/bundle.js';
 import 'oskari-loader!../../../packages/paikkatietoikkuna/bundle/mapmodule/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/oskariui/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapwfs2/bundle.js';
+import 'oskari-loader!oskari-frontend/packages/mapping/ol3/wfsmvt/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapuserlayers/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/ui-components/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/mapfull/bundle.js';

--- a/applications/paikkatietoikkuna.fi/published-map_ol3/main.js
+++ b/applications/paikkatietoikkuna.fi/published-map_ol3/main.js
@@ -3,6 +3,7 @@ import 'oskari-loader!../../../packages/paikkatietoikkuna/lang-overrides/bundle.
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapmodule/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapwmts/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapwfs2/bundle.js';
+import 'oskari-loader!oskari-frontend/packages/mapping/ol3/wfsmvt/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/maparcgis/bundle.js';
 import 'oskari-loader!oskari-frontend-contrib/packages/mapping/ol/mapanalysis/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol3/mapuserlayers/bundle.js';


### PR DESCRIPTION
Adds a missing bundle to the applications.

The wfsmvt bundle was included in minifierAppSetups, but since we got rid of those, we need to add these to the main files.