### PR TITLE
Make 3D bright again

### DIFF
--- a/bundles/paikkatietoikkuna/mapmodule/mapmodule.olcs.js
+++ b/bundles/paikkatietoikkuna/mapmodule/mapmodule.olcs.js
@@ -87,6 +87,9 @@ class MapModuleOlCesium extends MapModuleOl {
         scene.fog.density = 0.0005;
         scene.fog.screenSpaceErrorFactor = 10;
 
+        // Fix dark imagery
+        scene.highDynamicRange = false;
+
         var terrainProvider = new Cesium.CesiumTerrainProvider({
             url: TERRAIN_SERVICE_URL
         });


### PR DESCRIPTION
Turn `highDynamicRange` off to get bright layer imagery.