### PR TITLE
Update pti theming

### DIFF
--- a/theme.less
+++ b/theme.less
@@ -1,6 +1,6 @@
 // Available theme variables can be found in
 // https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
 
-@import '~oskari-frontend/ant-theme.less';
+@import '~oskari-frontend/src/react/ant-theme.less';
 
-@primary-color: #ebb819;
+// @primary-color: #ebb819;


### PR DESCRIPTION
Required after https://github.com/oskariorg/oskari-frontend/pull/999.

Update path to ant-theme.less
Comment out yellow primary color overwrite to use blue theme.
Leaving the comment there to implicate overwriting possibility.