### PR TITLE
Terrain-profile &nbsp

### DIFF
--- a/bundles/paikkatietoikkuna/terrain-profile/view/TerrainFlyout.js
+++ b/bundles/paikkatietoikkuna/terrain-profile/view/TerrainFlyout.js
@@ -204,7 +204,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.terrain-profile.TerrainFlyout',
                     text = me.loc('noValue');
                 }
                 cursor.select('text').text(text);
-
+                // replace no-break space
                 me.markerHandler.showAt(d.coords[0], d.coords[1], text.replace(/\u00A0/, ' '));
             }
 

--- a/bundles/paikkatietoikkuna/terrain-profile/view/TerrainFlyout.js
+++ b/bundles/paikkatietoikkuna/terrain-profile/view/TerrainFlyout.js
@@ -205,7 +205,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.terrain-profile.TerrainFlyout',
                 }
                 cursor.select('text').text(text);
 
-                me.markerHandler.showAt(d.coords[0], d.coords[1], text);
+                me.markerHandler.showAt(d.coords[0], d.coords[1], text.replace(/\u00A0/, ' '));
             }
 
             var processed;


### PR DESCRIPTION
Intl.NumberFormat uses &nbsp as space grouping char. Replace it by space for map marker.