### PR TITLE
Fix radio buttons on coordinate transformation UI

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                     '<div class="source-select">' +
                         '<input type="radio" id="clipboard" name="load" value="keyboard">' +
                         '<label for="keyboard">' +
-                            '<span/>' +
+                            '<span></span>' +
                             '${keyboard}' +
                         '</label>' +
                         '<div class="infolink icon-info" data-source="keyboard" title="${keyboardInfo}"></div>' +
@@ -24,7 +24,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                     '<div class="source-select">' +
                         '<input type="radio" id="file" name="load" value="file">' +
                         '<label for="file">' +
-                            '<span/>' +
+                            '<span></span>' +
                             '${file}' +
                         '</label>' +
                         '<div class="infolink icon-info" data-source="file" title="${fileInfo}"></div>' +
@@ -32,7 +32,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                     '<div class="source-select">' +
                         '<input type="radio" id="mapselection" name="load" value="map">' +
                         '<label for="mapselection">' +
-                            '<span/>' +
+                            '<span></span>' +
                             '${map}' +
                         '</label>' +
                         '<div class="infolink icon-info" data-source="map" title="${mapInfo}"></div>' +
@@ -52,7 +52,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                         // '<input type="radio" id="source-${type}" value="${type}">' +
                         // '<label for="source-${type}">' +
                         '<label>' +
-                            '<span/>' +
+                            '<span></span>' +
                             '${label}' +
                         '</label>' +
                         '<% if (obj.action) { %> ' +

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/CoordinateMapSelection.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/CoordinateMapSelection.js
@@ -11,11 +11,11 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.CoordinateMapSelection
                 '   <div class="coordinateSelectionOptions">' +
                 '       <input id="add-coordinate-to-map" type="radio" name="coordinate-map-select" value="add" checked/>' +
                 '       <label for="add-coordinate-to-map" class="source-select">' +
-                '           <span/>' +
+                '           <span></span>' +
                 '       </label>' +
                 '       <input id="remove-coordinate-from-map" type="radio" name="coordinate-map-select" value="remove"/>' +
                 '       <label for="remove-coordinate-from-map" class="source-select">' +
-                '            <span/>' +
+                '            <span></span>' +
                 '       </label>' +
                 '    </div>' +
                 '</div>'

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -79,7 +79,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                         '<div class="source-select">' +
                             '<input type="radio" id="filter-systems" name="filter-select" value="systems" checked>' +
                             '<label for="filter-systems">' +
-                                '<span/>' +
+                                '<span></span>' +
                                 '${systems}' +
                             '</label>' +
                 // '<div class="infolink icon-info" data-source="systems" title="${systemsInfo}"></div>' +
@@ -87,7 +87,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                         '<div class="source-select">' +
                             '<input type="radio" id="filter-epsg" name="filter-select" value="epsg">' +
                             '<label for="filter-epsg">' +
-                                '<span/>' +
+                                '<span></span>' +
                                 '${epsg}' +
                             '</label>' +
                 // '<div class="infolink icon-info" data-source="espg" title="${epsgInfo}"></div>' +


### PR DESCRIPTION
The radio buttons in coordinate transformation have visually broken after oskari-frontend 1.55.2 release. Suspecting it's because of the jQuery update https://github.com/oskariorg/oskari-frontend/pull/1282 but luckily the fix was easy. The empty spans are used for creating a radio-button'ish component. After 1.55.2 the text contents that previously were after the empty span tag in the DOM is now inside the span tag. This change fixes the DOM so text contents are again after the span and not inside it and makes the radio buttons visually correct.