### PR TITLE
CoordinateTransformation remove MacOS line ending option

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -184,10 +184,7 @@ Oskari.registerLocalization(
                     "radian": "Radian"
                 },
                 "lineSeparator": {
-                    "label": "Line separator", // Row separator
-                    "win": "Windows / DOS",
-                    "unix": "Unix",
-                    "mac": "MacOS"
+                    "label": "Line separator" // Row separator
                 },
                 "delimeters":{
                     "point": "Point",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -184,10 +184,7 @@ Oskari.registerLocalization(
                     "radian": "Radiaani"
                 },
                 "lineSeparator": {
-                    "label": "Rivierotin",
-                    "win": "Windows / DOS",
-                    "unix": "Unix",
-                    "mac": "MacOS"
+                    "label": "Rivierotin"
                 },
                 "delimeters":{
                     "point": "Piste",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -184,10 +184,7 @@ Oskari.registerLocalization(
                     "radian": "Radian"
                 },
                 "lineSeparator": {
-                    "label": "Radavskiljare",
-                    "win": "Windows / DOS",
-                    "unix": "Unix",
-                    "mac": "MacOS"
+                    "label": "Radavskiljare"
                 },
                 "delimeters":{
                     "point": "Punkt",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -88,8 +88,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                                             '<div class="settingsSelect">' +
                                                 '<select>' +
                                                     '<option value="win">Windows / DOS</option>' +
-                                                    '<option value="unix">Unix</option>' +
-                                                    '<option value="mac">MacOS</option>' +
+                                                    '<option value="unix">UNIX / Mac</option>' +
                                                 '</select>' +
                                             '</div>' +
                                             '<div class="infolink icon-info" data-selection="lineSeparator"></div>' +


### PR DESCRIPTION
Coordinate transformation service has only win and unix options for line endings. https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/pull/145

Remove mac option and update unix option label to: UNIX / Mac

Remove localization because code isn't using it and there's no need for localized labels.