### PR TITLE
Add announcements for testing

### DIFF
--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -70,4 +70,7 @@ import 'oskari-lazy-loader?appsetup!oskari-frontend/packages/admin/bundle/appset
 import 'oskari-lazy-loader?admin-layereditor!oskari-frontend/packages/admin/bundle/admin-layereditor/bundle.js';
 import 'oskari-lazy-loader?coordinatetransformation!../../packages/paikkatietoikkuna/bundle/coordinatetransformation/bundle.js';
 
+import 'oskari-lazy-loader?announcements!oskari-frontend/packages/framework/bundle/announcements/bundle.js';
+import 'oskari-lazy-loader?admin-announcements!oskari-frontend/packages/admin/bundle/admin-announcements/bundle.js';
+
 import './css/overwritten.css';


### PR DESCRIPTION
Use dynamic imports so they are not bundled in if we forget them for prod release. There's no migration to add these to apps yet (until we test if we want to have them) so you will need to run these in browsers dev-console:
```
Oskari.app.playBundle({ bundlename : 'announcements' });
Oskari.app.playBundle({ bundlename : 'admin-announcements' });
```
