### PR TITLE
Track layer error events

### DIFF
--- a/applications/geoportal/index.js
+++ b/applications/geoportal/index.js
@@ -42,6 +42,7 @@ jQuery(document).ready(function () {
 
             app.init(appSetup);
             app.startApplication(function () {
+                Oskari.app.playBundle({ bundlename: 'pti_layerstatus'});
                 var sb = Oskari.getSandbox();
                 gfiParamHandler(sb);
             });

--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -59,6 +59,7 @@ import 'oskari-loader!../../packages/paikkatietoikkuna/bundle/telemetry/bundle.j
 import 'oskari-loader!../../packages/paikkatietoikkuna/bundle/terrain-profile/bundle.js';
 import 'oskari-loader!../../packages/paikkatietoikkuna/lang-overrides/bundle.js';
 import 'oskari-loader!../../packages/paikkatietoikkuna/bundle/inspire/bundle.js';
+import 'oskari-loader!../../bundles/paikkatietoikkuna/layerstatus/bundle.js';
 
 // lazy
 import 'oskari-lazy-loader?admin-layerselector!oskari-frontend/packages/integration/bundle/admin-layerselector/bundle.js';

--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -62,8 +62,6 @@ import 'oskari-loader!../../packages/paikkatietoikkuna/bundle/inspire/bundle.js'
 import 'oskari-loader!../../bundles/paikkatietoikkuna/layerstatus/bundle.js';
 
 // lazy
-import 'oskari-lazy-loader?admin-layerselector!oskari-frontend/packages/integration/bundle/admin-layerselector/bundle.js';
-import 'oskari-lazy-loader?admin-layerselector!oskari-frontend/packages/integration/bundle/bb/bundle.js';
 import 'oskari-lazy-loader?admin-layerrights!oskari-frontend/packages/framework/bundle/admin-layerrights/bundle.js';
 import 'oskari-lazy-loader?admin!oskari-frontend/packages/admin/bundle/admin/bundle.js';
 import 'oskari-lazy-loader?metrics!oskari-frontend/packages/admin/bundle/metrics/bundle.js';

--- a/bundles/paikkatietoikkuna/layerstatus/bundle.js
+++ b/bundles/paikkatietoikkuna/layerstatus/bundle.js
@@ -3,19 +3,19 @@
  *
  * Definition for bundle. See source for details.
  */
- Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundle', function () {}, {
-    "create": function () {
+Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundle', function () { }, {
+    'create': function () {
         return Oskari.clazz.create('Oskari.pti.layerstatus.StatusBundleInstance');
     },
-    "update": function (manager, bundle, bi, info) {}
+    'update': function (manager, bundle, bi, info) { }
 }, {
-    "protocol": ["Oskari.bundle.Bundle"],
-    "source": {
-        "scripts": [{
-            "type": "text/javascript",
-            "src": "./instance.js"
+    'protocol': ['Oskari.bundle.Bundle'],
+    'source': {
+        'scripts': [{
+            'type': 'text/javascript',
+            'src': './instance.js'
         }]
     }
 });
 
-Oskari.bundle_manager.installBundleClass("pti_layerstatus", "Oskari.pti.layerstatus.StatusBundle");
+Oskari.bundle_manager.installBundleClass('pti_layerstatus', 'Oskari.pti.layerstatus.StatusBundle');

--- a/bundles/paikkatietoikkuna/layerstatus/bundle.js
+++ b/bundles/paikkatietoikkuna/layerstatus/bundle.js
@@ -1,5 +1,5 @@
 /**
- * @class Oskari.mapframework.bundle.telemetry.TelemetryBundle
+ * @class Oskari.pti.layerstatus.StatusBundle
  *
  * Definition for bundle. See source for details.
  */

--- a/bundles/paikkatietoikkuna/layerstatus/bundle.js
+++ b/bundles/paikkatietoikkuna/layerstatus/bundle.js
@@ -1,0 +1,21 @@
+/**
+ * @class Oskari.mapframework.bundle.telemetry.TelemetryBundle
+ *
+ * Definition for bundle. See source for details.
+ */
+ Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundle', function () {}, {
+    "create": function () {
+        return Oskari.clazz.create('Oskari.pti.layerstatus.StatusBundleInstance');
+    },
+    "update": function (manager, bundle, bi, info) {}
+}, {
+    "protocol": ["Oskari.bundle.Bundle"],
+    "source": {
+        "scripts": [{
+            "type": "text/javascript",
+            "src": "./instance.js"
+        }]
+    }
+});
+
+Oskari.bundle_manager.installBundleClass("pti_layerstatus", "Oskari.pti.layerstatus.StatusBundle");

--- a/bundles/paikkatietoikkuna/layerstatus/instance.js
+++ b/bundles/paikkatietoikkuna/layerstatus/instance.js
@@ -1,17 +1,18 @@
-/**
- * @class Oskari.mapframework.bundle.telemetry.TelemetryBundleInstance
- */
- Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
+// state values for layer loading statuses
+const STATE = {
+    ERROR: 'error',
+    SUCCESS: 'success'
+};
 
+/**
+ * @class Oskari.pti.layerstatus.StatusBundleInstance
+ */
+Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
+    // no-op
 }, {
     __name: 'LayerStatusBundleInstance',
     __loadingStatus: {},
-    _startImpl: function (sandbox) {        
-        const STATE = {
-            ERROR: 'error',
-            SUCCESS: 'success'
-        };
-        let loadingStats = this.__loadingStatus;
+    _startImpl: function (sandbox) {    
         const map = sandbox.findRegisteredModuleInstance('MainMapModule');
         map.on('layer.loading', (event) => {
             // event: {layer: 801, started: true, errored: false}
@@ -19,31 +20,64 @@
                 // don't care about start events
                 return;
             }
-            let stats = loadingStats[event.layer] || { errors: 0, success: 0, stack: [], previous: STATE.SUCCESS };
-            let currentState = STATE.SUCCESS;
-            if (event.errored) {
-                stats.errors++
-                currentState = STATE.ERROR;
-            } else {
-                stats.success++;
+            this._handleLoadingEvent(event.layer, event.errored);
+        });
+        
+        window.addEventListener('beforeunload', () => {
+            // just fire and forget when the user leaves the page
+            this._sendStatus();
+        });
+    },
+    _handleLoadingEvent: function (layer, wasError) {
+        let stats = this._getLayerStatus(layer);
+        let currentState = STATE.SUCCESS;
+        if (wasError) {
+            stats.errors++
+            currentState = STATE.ERROR;
+        } else {
+            stats.success++;
+        }
+        
+        if (stats.previous !== currentState) {
+            stats.previous = currentState;
+            // for the first 10 state changes:
+            // save stack for current state with center coord and zoom level
+            if (stats.stack.length < 10) {
+                const mapState = sandbox.getMap();
+                stats.stack.push({
+                    x: mapState.getX(),
+                    y: mapState.getY(),
+                    z: mapState.getZoom(),
+                    state: currentState,
+                    layers: mapState.getLayers().map(l => l.getId())
+                });
             }
-            
-            if (stats.previous !== currentState) {
-                stats.previous = currentState;
-                // for the first 10 state changes:
-                // save stack for current state with center coord and zoom level
-                if (stats.stack.length < 10) {
-                    const mapState = sandbox.getMap();
-                    stats.stack.push({
-                        x: mapState.getX(),
-                        y: mapState.getY(),
-                        z: mapState.getZoom(),
-                        state: currentState,
-                        layers: mapState.getLayers().map(l => l.getId())
-                    });
-                }
-            }
-            loadingStats[event.layer] = stats;
+        }
+    },
+    _getLayerStatus: function (layerId) {
+        if (!layerId) {
+            return this.__loadingStatus;
+        }
+
+        let stats = this.__loadingStatus[layerId];
+        if (stats) {
+             return stats;
+        }
+        this.__loadingStatus[layerId] = {
+            errors: 0,
+            success: 0,
+            stack: [],
+            previous: STATE.SUCCESS
+        };
+        return this.__loadingStatus[layerId];
+    },
+    _sendStatus: function () {
+        fetch(Oskari.urls.getRoute('LayerStatus'), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(this._getLayerStatus()),
         });
     }
 }, {

--- a/bundles/paikkatietoikkuna/layerstatus/instance.js
+++ b/bundles/paikkatietoikkuna/layerstatus/instance.js
@@ -12,7 +12,7 @@ Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
 }, {
     __name: 'LayerStatusBundleInstance',
     __loadingStatus: {},
-    _startImpl: function (sandbox) {    
+    _startImpl: function (sandbox) {
         const map = sandbox.findRegisteredModuleInstance('MainMapModule');
         map.on('layer.loading', (event) => {
             // event: {layer: 801, started: true, errored: false}
@@ -22,28 +22,28 @@ Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
             }
             this._handleLoadingEvent(event.layer, event.errored);
         });
-        
+
         window.addEventListener('beforeunload', () => {
             // just fire and forget when the user leaves the page
             this._sendStatus();
         });
     },
     _handleLoadingEvent: function (layer, wasError) {
-        let stats = this._getLayerStatus(layer);
+        const stats = this._getLayerStatus(layer);
         let currentState = STATE.SUCCESS;
         if (wasError) {
-            stats.errors++
+            stats.errors++;
             currentState = STATE.ERROR;
         } else {
             stats.success++;
         }
-        
+
         if (stats.previous !== currentState) {
             stats.previous = currentState;
             // for the first 10 state changes:
             // save stack for current state with center coord and zoom level
             if (stats.stack.length < 10) {
-                const mapState = sandbox.getMap();
+                const mapState = this.sandbox.getMap();
                 stats.stack.push({
                     x: mapState.getX(),
                     y: mapState.getY(),
@@ -61,7 +61,7 @@ Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
 
         let stats = this.__loadingStatus[layerId];
         if (stats) {
-             return stats;
+            return stats;
         }
         this.__loadingStatus[layerId] = {
             errors: 0,
@@ -75,9 +75,9 @@ Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
         fetch(Oskari.urls.getRoute('LayerStatus'), {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify(this._getLayerStatus()),
+            body: JSON.stringify(this._getLayerStatus())
         });
     }
 }, {

--- a/bundles/paikkatietoikkuna/layerstatus/instance.js
+++ b/bundles/paikkatietoikkuna/layerstatus/instance.js
@@ -1,0 +1,52 @@
+/**
+ * @class Oskari.mapframework.bundle.telemetry.TelemetryBundleInstance
+ */
+ Oskari.clazz.define('Oskari.pti.layerstatus.StatusBundleInstance', function () {
+
+}, {
+    __name: 'LayerStatusBundleInstance',
+    __loadingStatus: {},
+    _startImpl: function (sandbox) {        
+        const STATE = {
+            ERROR: 'error',
+            SUCCESS: 'success'
+        };
+        let loadingStats = this.__loadingStatus;
+        const map = sandbox.findRegisteredModuleInstance('MainMapModule');
+        map.on('layer.loading', (event) => {
+            // event: {layer: 801, started: true, errored: false}
+            if (event.started) {
+                // don't care about start events
+                return;
+            }
+            let stats = loadingStats[event.layer] || { errors: 0, success: 0, stack: [], previous: STATE.SUCCESS };
+            let currentState = STATE.SUCCESS;
+            if (event.errored) {
+                stats.errors++
+                currentState = STATE.ERROR;
+            } else {
+                stats.success++;
+            }
+            
+            if (stats.previous !== currentState) {
+                stats.previous = currentState;
+                // for the first 10 state changes:
+                // save stack for current state with center coord and zoom level
+                if (stats.stack.length < 10) {
+                    const mapState = sandbox.getMap();
+                    stats.stack.push({
+                        x: mapState.getX(),
+                        y: mapState.getY(),
+                        z: mapState.getZoom(),
+                        state: currentState,
+                        layers: mapState.getLayers().map(l => l.getId())
+                    });
+                }
+            }
+            loadingStats[event.layer] = stats;
+        });
+    }
+}, {
+    'extend': ['Oskari.BasicBundle'],
+    'protocol': ['Oskari.bundle.BundleInstance', 'Oskari.mapframework.module.Module']
+});


### PR DESCRIPTION
Send info about layer usage and errors when loading layers when the user exits the page. The purpose is to determine which layers should be marked unstable or in an error status for the end-users.