### PR TITLE
Add custom formatter for PTI historical ortophotos

### DIFF
--- a/applications/geoportal/index.js
+++ b/applications/geoportal/index.js
@@ -1,4 +1,4 @@
-'use strict';
+import { PTIOrtophotoTimeseriesGFIformatter } from '../../util/PTIOrtophotoTimeseriesGFIformatter';
 /**
  * Start when dom ready
  */
@@ -43,7 +43,10 @@ jQuery(document).ready(function () {
             app.init(appSetup);
             app.startApplication(function () {
                 Oskari.app.playBundle({ bundlename: 'pti_layerstatus'});
+                
                 var sb = Oskari.getSandbox();
+                sb.findRegisteredModuleInstance('MainMapModuleGetInfoPlugin')
+                    .addLayerFormatter(new PTIOrtophotoTimeseriesGFIformatter());
                 gfiParamHandler(sb);
             });
         },

--- a/util/PTIOrtophotoTimeseriesGFIformatter.js
+++ b/util/PTIOrtophotoTimeseriesGFIformatter.js
@@ -1,0 +1,54 @@
+/**
+ * Paikkatietoikkunan vanhojen ilmakuvien esittämiseen GFI-vastauksen muotoiluun tehty koodi.
+ * Tason GFI-vastauksen oletetaan olevan Stringinä annettua GeoJSON:ia, josta haetaan
+ * kaikista kohteista se, jolla on viimeisin vuosi.
+ * 
+ * - muotoilun käyttöönotto tasolle: layer.attributes.PTI_GFI_formatter = "latestPhotoYear"
+ * - muotoilussa haettavan ominaisuustiedon nimi: layer.attributes.PTI_GFI_property = "[ominaisuustietokentän nimi]", määrittelemättömänä "kuvausvuosi"
+ * - käyttäjälle näytettävä teksti: layer.attributes.PTI_GFI_label (voi olla string tai locale object, määrittelemättömänä "Vuosi")
+ * 
+ * Esim attributes kenttään: 
+ * {
+    "PTI_GFI_formatter": "latestPhotoYear",
+    "PTI_GFI_property": "kuvausvuosi",
+    "PTI_GFI_label": {
+        "fi": "Vuosi",
+        "en": "Year"
+    }
+   }
+ * 
+ * Käyttöönotto esim. applications alla index.js:ssä:
+ * 
+ *     import { PTIOrtophotoTimeseriesGFIformatter } from '../../util/PTIOrtophotoTimeseriesGFIformatter';
+ *
+ * Oskari.app.startApplication() callbackissä:
+ * 
+ *     sandbox.findRegisteredModuleInstance('MainMapModuleGetInfoPlugin').addLayerFormatter(new PTIOrtophotoTimeseriesGFIformatter());
+ */
+export class PTIOrtophotoTimeseriesGFIformatter {
+    enabled (data = {}) {
+        const layerAttributes = this.getLayerAttributes(data.layerId);
+        return layerAttributes.PTI_GFI_formatter === "latestPhotoYear";
+    }
+
+    format (data = {}) {
+        const layerAttributes = this.getLayerAttributes(data.layerId);
+        try {
+            const geojson = JSON.parse(data.content);
+            const photoYearAttr = layerAttributes.PTI_GFI_property || 'kuvausvuosi';
+            const label = Oskari.getLocalized(layerAttributes.PTI_GFI_label || 'Vuosi');
+            const years = geojson.features.map(feature => parseInt(feature.properties[photoYearAttr], 10));
+            return `<b>${label}:</b> ${Math.max(...years)}`;
+        } catch (err) {
+            Oskari.log('PTIOrtophotoTimeseriesGFIformatter').warn(`Couldn't format GFI data`, data);
+        }
+    }
+
+    getLayerAttributes (id) {
+        const layer = Oskari.getSandbox().getService('Oskari.mapframework.service.MapLayerService').findMapLayer(id);
+        if (!layer) {
+            return {};
+        }
+        return layer.getAttributes() || {};
+    }
+};


### PR DESCRIPTION
Uses oskariorg/oskari-frontend#1481 to customize GFI response formatting for historical ortophotos.

Configured with admin-layereditor by adding something like this to layer attributes field:
```
{
    "PTI_GFI_formatter": "latestPhotoYear",
    "PTI_GFI_property": "kuvausvuosi",
    "PTI_GFI_label": {
        "fi": "Vuosi",
        "en": "Year"
    }
}
```