### PR TITLE
Remove unnecessary localization variable

### DIFF
--- a/bundles/paikkatietoikkuna/inspire/Flyout.js
+++ b/bundles/paikkatietoikkuna/inspire/Flyout.js
@@ -6,7 +6,6 @@ Oskari.clazz.define('Oskari.inspire.Flyout',
 
     function (instance) {
         this.instance = instance;
-        this.loc = Oskari.getMsg.bind(null, 'inspire');
         this.container = null;
         this.flyout = null;
     }, {


### PR DESCRIPTION
We use localization of bundle instance so local localization is unnecessary.