### PR TITLE
Visual fix caused by AntD reset css/box-sizing

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/coordinatetransformation.css
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/css/coordinatetransformation.css
@@ -228,7 +228,7 @@
 }
 .coordinatetransformation .cellContent {
     text-align: center;
-    height: 12px;
+    height: 27px;
     padding-bottom: 7px;
     padding-top: 8px;
     overflow: hidden;


### PR DESCRIPTION
Related oskariorg/oskari-frontend#1629 / AntD CSS reset with box-sizing: border-box for all components.