### PR TITLE
Check if plugin exists before attaching formatter

### DIFF
--- a/applications/embedded/main.js
+++ b/applications/embedded/main.js
@@ -35,7 +35,9 @@ import { PTIOrtophotoTimeseriesGFIformatter } from '../../util/PTIOrtophotoTimes
 import './css/overwritten.css';
 
 Oskari.on('app.start', () => {
-    Oskari.getSandbox()
-        .findRegisteredModuleInstance('MainMapModuleGetInfoPlugin')
-        .addLayerFormatter(new PTIOrtophotoTimeseriesGFIformatter());
+    var plugin = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModuleGetInfoPlugin');
+    if (plugin) {
+        // not all embedded maps have the plugin
+        plugin.addLayerFormatter(new PTIOrtophotoTimeseriesGFIformatter());
+    }
 });


### PR DESCRIPTION
To get rid of a warning when the plugin is not part of the embedded map.