### PR TITLE
Switch to new statsgrid in all apps

### DIFF
--- a/applications/embedded-3D/main.js
+++ b/applications/embedded-3D/main.js
@@ -32,7 +32,7 @@ import 'oskari-lazy-loader?maplegend!oskari-frontend/packages/framework/bundle/m
 import 'oskari-lazy-loader?featuredata!oskari-frontend/packages/framework/featuredata/bundle.js';
 import 'oskari-lazy-loader?routingService!oskari-frontend/packages/framework/bundle/routingService/bundle.js';
 import 'oskari-lazy-loader?feedbackService!oskari-frontend/packages/framework/bundle/feedbackService/bundle.js';
-import 'oskari-lazy-loader?statsgrid!oskari-frontend/packages/statistics/statsgrid/bundle.js';
+import 'oskari-lazy-loader?statsgrid!oskari-frontend/bundles/statistics/statsgrid/bundle.js';
 
 import { PTIOrtophotoTimeseriesGFIformatter } from '../../util/PTIOrtophotoTimeseriesGFIformatter';
 

--- a/applications/embedded/main.js
+++ b/applications/embedded/main.js
@@ -28,7 +28,7 @@ import 'oskari-lazy-loader?maplegend!oskari-frontend/packages/framework/bundle/m
 import 'oskari-lazy-loader?featuredata!oskari-frontend/packages/framework/featuredata/bundle.js';
 import 'oskari-lazy-loader?routingService!oskari-frontend/packages/framework/bundle/routingService/bundle.js';
 import 'oskari-lazy-loader?feedbackService!oskari-frontend/packages/framework/bundle/feedbackService/bundle.js';
-import 'oskari-lazy-loader?statsgrid!oskari-frontend/packages/statistics/statsgrid/bundle.js';
+import 'oskari-lazy-loader?statsgrid!oskari-frontend/bundles/statistics/statsgrid/bundle.js';
 
 import 'oskari-lazy-loader?metadataflyout!oskari-frontend/packages/catalogue/bundle/metadataflyout/bundle.js';
 import 'oskari-lazy-loader?metadatasearch!oskari-frontend/packages/catalogue/metadatasearch/bundle.js';

--- a/applications/geoportal-3D/main.js
+++ b/applications/geoportal-3D/main.js
@@ -53,7 +53,7 @@ import 'oskari-lazy-loader?publisher2!oskari-frontend/packages/framework/bundle/
 import 'oskari-lazy-loader?printout!oskari-frontend/packages/framework/bundle/printout/bundle.js';
 import 'oskari-lazy-loader?userguide!oskari-frontend/packages/framework/bundle/userguide/bundle.js';
 import 'oskari-lazy-loader?coordinatetransformation!../../packages/paikkatietoikkuna/bundle/coordinatetransformation/bundle.js';
-import 'oskari-lazy-loader?statsgrid!oskari-frontend/packages/statistics/statsgrid/bundle.js';
+import 'oskari-lazy-loader?statsgrid!oskari-frontend/bundles/statistics/statsgrid/bundle.js';
 import 'oskari-lazy-loader?terrain-profile!oskari-frontend-contrib/packages/terrain-profile/bundle.js';
 import 'oskari-lazy-loader?featuredata!oskari-frontend/packages/framework/featuredata/bundle.js';
 import 'oskari-lazy-loader?metadataflyout!oskari-frontend/packages/catalogue/bundle/metadataflyout/bundle.js';


### PR DESCRIPTION
Related to https://github.com/nls-oskari/pti-frontend/pull/132 /  https://github.com/nls-oskari/pti-frontend/commit/fb4c441ff1151944eba9e8e813a35636a6677c8a

The statsgrid is always loaded lazily. In geoportal so we can leave it out for mobile users and for embedded maps we can leave it out if the publisher isn't using thematic maps. However all lazy-loaded bundles are written parallel to the app-specific folders under dist:
```
embedded <- app
geoportal <- app
resources
...
vendors~chunk_statsgrid  <- lazy loaded bundle used by both apps
```
What happens when embedded and geoportal uses a bundle with the _same id_ but _different source folder_ AND the lazy-loaded bundles _are shared_? Probably chaos ensues...