### PR TITLE
CoordTrans encode export settings

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/service/TransformationService.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/service/TransformationService.js
@@ -47,7 +47,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.TransformationService',
                 urlParameterString += '&targetHeightCrs=' + crs.targetElevationCrs;
             }
             if (exportSettings) {
-                urlParameterString += '&exportSettings=' + JSON.stringify(exportSettings.selects);
+                urlParameterString += '&exportSettings=' + encodeURIComponent(JSON.stringify(exportSettings.selects));
             }
             return urlBase + urlParameterString;
         },


### PR DESCRIPTION
Encode export settings for A2F transform because Tomcat doesn't like JSON chars in query params.

First tried to use FormData like F2F transformation but backend parses input coords (table/array) from input stream (also for A2A transformation)  so it would require more changes that I thought. As frontend uses jQuery it will be refactored so made only quick fix for now.