### PR TITLE
Fix start:dev for windows env

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "npm run dev-mode:off && webpack --config ./node_modules/oskari-frontend/webpack.config.js --mode production --progress --env appdef=applications --env theme=theme.less",
     "start": "npm run dev-mode:off && webpack-dev-server --config ./node_modules/oskari-frontend/webpack.config.js --hot --env appdef=applications --env theme=theme.less",
     "build:dev": "npm run dev-mode:on && node ./node_modules/oskari-frontend/node_modules/webpack/bin/webpack.js --config ./node_modules/oskari-frontend/webpack.config.js --mode production --progress --env appdef=applications --env theme=theme.less",
-    "start:dev": "npm run dev-mode:on && node ./node_modules/oskari-frontend/node_modules/webpack-dev-server/bin/webpack-dev-server.js --config ./node_modules/oskari-frontend/webpack.config.js --hot --env appdef='devapp:applications' --env theme=theme.less",
+    "start:dev": "npm run dev-mode:on && node ./node_modules/oskari-frontend/node_modules/webpack-dev-server/bin/webpack-dev-server.js --config ./node_modules/oskari-frontend/webpack.config.js --hot --env appdef=devapp:applications --env theme=theme.less",
     "sprite": "node ./node_modules/oskari-frontend/webpack/sprite.js",
     "test": "eslint --config ./node_modules/oskari-frontend/.eslintrc.js bundles",
     "generate-bom": "cyclonedx-bom --include-dev -o frontend-bom.json"


### PR DESCRIPTION
#143 added ' around the appdef env-parameter value which breaks it for Windows env. Seems they are not needed atleast on WSL env so removing them.