### PR TITLE
Switch admin-layerrights -> admin-permissions in 3d

### DIFF
--- a/applications/geoportal-3D/main.js
+++ b/applications/geoportal-3D/main.js
@@ -62,7 +62,7 @@ import 'oskari-lazy-loader?metadatasearch!oskari-frontend/packages/catalogue/met
 import 'oskari-lazy-loader?mobileuserguide!../../bundles/paikkatietoikkuna/mobileuserguide/bundle.js';
 // end mobile tuning
 // lazy
-import 'oskari-lazy-loader?admin-layerrights!oskari-frontend/packages/framework/bundle/admin-layerrights/bundle.js';
+import 'oskari-lazy-loader?admin-permissions!oskari-frontend/packages/admin/bundle/admin-permissions/bundle.js';
 import 'oskari-lazy-loader?admin!oskari-frontend/packages/admin/bundle/admin/bundle.js';
 import 'oskari-lazy-loader?metrics!oskari-frontend/packages/admin/bundle/metrics/bundle.js';
 import 'oskari-lazy-loader?appsetup!oskari-frontend/packages/admin/bundle/appsetup/bundle.js';

--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -71,7 +71,6 @@ import 'oskari-loader!oskari-frontend/bundles/framework/layeranalytics/bundle.js
 // lazy
 
 import 'oskari-lazy-loader?admin-permissions!oskari-frontend/packages/admin/bundle/admin-permissions/bundle.js';
-//import 'oskari-lazy-loader?admin-layerrights!oskari-frontend/packages/framework/bundle/admin-layerrights/bundle.js';
 import 'oskari-lazy-loader?admin!oskari-frontend/packages/admin/bundle/admin/bundle.js';
 import 'oskari-lazy-loader?metrics!oskari-frontend/packages/admin/bundle/metrics/bundle.js';
 import 'oskari-lazy-loader?appsetup!oskari-frontend/packages/admin/bundle/appsetup/bundle.js';


### PR DESCRIPTION
The `admin-layerrights` was removed in 3.0