### PR TITLE
CoordTrans remove lodash

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
@@ -15,35 +15,35 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
         this._template = {
             systemWrapper: jQuery('<div class="coordinate-system-wrapper"></div>'),
             coordinateSystemSelection: obj =>
-                `<h4>${ obj.title }</h4>
+                `<h4>${obj.title}</h4>
                 <div class="transformation-system">
                     <div class="system epsgSearch selection-wrapper">
-                        <b class="dropdown_title">${ obj.epsg_search }</b>
+                        <b class="dropdown_title">${obj.epsg_search}</b>
                         <input type="text" placeholder="3067"/>
                         <div class="infolink icon-info" data-system="epsgSearch" title="${obj.tooltip.epsgSearch}"></div>
                     </div>
                     <div class="system datum selection-wrapper system-filter">
-                        <b class="dropdown_title"> ${ obj.geodetic_datum }</b>
+                        <b class="dropdown_title"> ${obj.geodetic_datum}</b>
                         <div class="selectMountPoint"></div>
                         <div class="infolink icon-info" data-system="geodeticDatum" title="${obj.tooltip.geodeticDatum}"></div>
                     </div>
                     <div class="system coordinate selection-wrapper system-filter">
-                        <b class="dropdown_title"> ${ obj.coordinate_system }</b>
+                        <b class="dropdown_title"> ${obj.coordinate_system}</b>
                         <div class="selectMountPoint"></div>
                         <div class="infolink icon-info" data-system="coordinateSystem" title="${obj.tooltip.coordinateSystem}"></div>
                     </div>
                     <div class="system projection selection-wrapper system-filter">
-                        <b class="dropdown_title"> ${ obj.map_projection }</b>
+                        <b class="dropdown_title"> ${obj.map_projection}</b>
                         <div class="selectMountPoint"></div>
                         <div class="infolink icon-info" data-system="mapProjection" title="${obj.tooltip.mapProjection}"></div>
                     </div>
                     <div class="system geodetic-coordinate selection-wrapper">
-                        <b class="dropdown_title"> ${ obj.geodetic_coordinate_system } *</b>
+                        <b class="dropdown_title"> ${obj.geodetic_coordinate_system} *</b>
                         <div class="selectMountPoint"></div>
                         <div class="infolink icon-info" data-system="geodeticCoordinateSystem" title="${obj.tooltip.geodeticCoordinateSystem}"></div>
                     </div>
                     <div class="system elevation selection-wrapper">
-                        <b class="dropdown_title"> ${ obj.elevation_system } </b>
+                        <b class="dropdown_title"> ${obj.elevation_system} </b>
                         <div class="selectMountPoint"></div>
                         <div class="infolink icon-info" data-system="heightSystem" title="${obj.tooltip.heightSystem}"></div>
                     </div>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateSystemSelection.js
@@ -1,5 +1,3 @@
-import { template } from 'lodash';
-
 Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemSelection',
     function (view, loc, type, helper) {
         this.view = view;
@@ -16,41 +14,40 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateSystemS
         this.isAxisFlip = false;
         this._template = {
             systemWrapper: jQuery('<div class="coordinate-system-wrapper"></div>'),
-            coordinateSystemSelection: template(
-                '<h4> ${ title }</h4>' +
-                '<div class="transformation-system">' +
-                    '<div class="system epsgSearch selection-wrapper">' +
-                        '<b class="dropdown_title">${ epsg_search }</b>' +
-                        '<input type="text" placeholder="3067"/>' +
-                        '<div class="infolink icon-info" data-system="epsgSearch" title="${tooltip.epsgSearch}"></div>' +
-                    '</div>' +
-                    '<div class="system datum selection-wrapper system-filter">' +
-                        '<b class="dropdown_title"> ${ geodetic_datum }</b>' +
-                        '<div class="selectMountPoint"></div>' +
-                        '<div class="infolink icon-info" data-system="geodeticDatum" title="${tooltip.geodeticDatum}"></div>' +
-                    '</div>' +
-                    '<div class="system coordinate selection-wrapper system-filter">' +
-                        '<b class="dropdown_title"> ${ coordinate_system }</b>' +
-                        '<div class="selectMountPoint"></div>' +
-                        '<div class="infolink icon-info" data-system="coordinateSystem" title="${tooltip.coordinateSystem}"></div>' +
-                    '</div>' +
-                    '<div class="system projection selection-wrapper system-filter">' +
-                        '<b class="dropdown_title"> ${ map_projection }</b>' +
-                        '<div class="selectMountPoint"></div>' +
-                        '<div class="infolink icon-info" data-system="mapProjection" title="${tooltip.mapProjection}"></div>' +
-                    '</div>' +
-                    '<div class="system geodetic-coordinate selection-wrapper">' +
-                        '<b class="dropdown_title"> ${ geodetic_coordinate_system } *</b>' +
-                        '<div class="selectMountPoint"></div>' +
-                        '<div class="infolink icon-info" data-system="geodeticCoordinateSystem" title="${tooltip.geodeticCoordinateSystem}"></div>' +
-                    '</div>' +
-                    '<div class="system elevation selection-wrapper">' +
-                        '<b class="dropdown_title"> ${ elevation_system } </b>' +
-                        '<div class="selectMountPoint"></div>' +
-                        '<div class="infolink icon-info" data-system="heightSystem" title="${tooltip.heightSystem}"></div>' +
-                    '</div>' +
-                '</div>'
-            )
+            coordinateSystemSelection: obj =>
+                `<h4>${ obj.title }</h4>
+                <div class="transformation-system">
+                    <div class="system epsgSearch selection-wrapper">
+                        <b class="dropdown_title">${ obj.epsg_search }</b>
+                        <input type="text" placeholder="3067"/>
+                        <div class="infolink icon-info" data-system="epsgSearch" title="${obj.tooltip.epsgSearch}"></div>
+                    </div>
+                    <div class="system datum selection-wrapper system-filter">
+                        <b class="dropdown_title"> ${ obj.geodetic_datum }</b>
+                        <div class="selectMountPoint"></div>
+                        <div class="infolink icon-info" data-system="geodeticDatum" title="${obj.tooltip.geodeticDatum}"></div>
+                    </div>
+                    <div class="system coordinate selection-wrapper system-filter">
+                        <b class="dropdown_title"> ${ obj.coordinate_system }</b>
+                        <div class="selectMountPoint"></div>
+                        <div class="infolink icon-info" data-system="coordinateSystem" title="${obj.tooltip.coordinateSystem}"></div>
+                    </div>
+                    <div class="system projection selection-wrapper system-filter">
+                        <b class="dropdown_title"> ${ obj.map_projection }</b>
+                        <div class="selectMountPoint"></div>
+                        <div class="infolink icon-info" data-system="mapProjection" title="${obj.tooltip.mapProjection}"></div>
+                    </div>
+                    <div class="system geodetic-coordinate selection-wrapper">
+                        <b class="dropdown_title"> ${ obj.geodetic_coordinate_system } *</b>
+                        <div class="selectMountPoint"></div>
+                        <div class="infolink icon-info" data-system="geodeticCoordinateSystem" title="${obj.tooltip.geodeticCoordinateSystem}"></div>
+                    </div>
+                    <div class="system elevation selection-wrapper">
+                        <b class="dropdown_title"> ${ obj.elevation_system } </b>
+                        <div class="selectMountPoint"></div>
+                        <div class="infolink icon-info" data-system="heightSystem" title="${obj.tooltip.heightSystem}"></div>
+                    </div>
+                </div>`
         };
         this.createUi();
         Oskari.makeObservable(this);

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.js
@@ -1,5 +1,3 @@
-import { template } from 'lodash';
-
 Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateTable', function (view, loc, type) {
     this.loc = loc;
     this.type = type;
@@ -9,42 +7,42 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.CoordinateTable',
     this.isEditable = false;
     this.scrollTimer = null;
     this.template = {
-        tableWrapper: template('<div class="coordinate-table-wrapper <%= type %>">' +
-                                        '<h5> <%= title %> </h5>' +
-                                        '<div class="oskari-table-header"></div>' +
-                                        '<div class="oskari-table-content"></div>' +
-                                    '</div>'
-        ),
-        rowcounter: template('<div class="rowcount"><span class="row-counter">0</span> ${rows} </div>'),
-        header: template('<table class="oskari-tbl-header" cellpadding="0" cellspacing="0" border="0">' +
-                                '<thead>' +
-                                    '<tr>' +
-                                        '<th>${col1}</th>' +
-                                        '<th>${col2}</th>' +
-                                        '<th class="elevation">${elev}</th>' +
-                                    '</tr>' +
-                                 '</thead>' +
-                            '</table>'
-        ),
-        row: template('<tr>' +
-                                '<td class="cell">' +
-                                    '<div class="cellContent">${coords.col1}</div>' +
-                                '</td>' +
-                                '<td class="cell">' +
-                                    '<div class="cellContent">${coords.col2}</div>' +
-                                '</td>' +
-                                '<td class="cell elevation oskari-hidden">' +
-                                    '<div class="cellContent">${coords.elev}</div>' +
-                                '</td>' +
-                                '<td class="cell control">' +
-                                    '<div class="removerow"></div>' +
-                                '</td>' +
-                            '</tr> '
-        ),
-        table: template('<table class="hoverable oskari-coordinate-table two-dimensions" cellpadding="0" cellspacing="0" border="0">' +
-                                '<tbody></tbody' +
-                            '</table>'
-        )
+        tableWrapper: ({ type, title }) =>
+            `<div class="coordinate-table-wrapper ${type}">
+                <h5>${title}</h5>
+                <div class="oskari-table-header"></div>
+                <div class="oskari-table-content"></div>
+            </div>`,
+        rowcounter: ({ rows }) => `<div class="rowcount"><span class="row-counter">0</span> ${rows}</div>`,
+        header: ({ col1, col2, elev }) =>
+            `<table class="oskari-tbl-header" cellpadding="0" cellspacing="0" border="0">
+                <thead>
+                    <tr>
+                        <th>${col1}</th>
+                        <th>${col2}</th>
+                        <th class="elevation">${elev}</th>
+                    </tr>
+                    </thead>
+            </table>`,
+        row: ({ coords }) =>
+            `<tr>
+                <td class="cell">
+                    <div class="cellContent">${coords.col1 || ''}</div>
+                </td>
+                <td class="cell">
+                    <div class="cellContent">${coords.col2 || ''}</div>
+                </td>
+                <td class="cell elevation oskari-hidden">
+                    <div class="cellContent">${coords.elev || ''}</div>
+                </td>
+                <td class="cell control">
+                    <div class="removerow"></div>
+                </td>
+            </tr>`,
+        table: () =>
+            `<table class="hoverable oskari-coordinate-table two-dimensions" cellpadding="0" cellspacing="0" border="0">
+                <tbody></tbody
+            </table>`
     };
 }, {
     getContainer: function () {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
@@ -56,8 +56,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                             `<div class="action-link">
                                 <div>&nbsp-&nbsp</div>
                                 <a href="javascript:void(0);">${action}</a>
-                            </div>`
-                        }
+                            </div>`}
                     </div>
                     <div class="infolink icon-info" data-source="${type}" title="${tooltip}"></div>
                 </div>`,

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
@@ -1,5 +1,3 @@
-import { template } from 'lodash';
-
 Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
     function (loc) {
         Oskari.makeObservable(this);
@@ -47,25 +45,22 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                 // '<div class="datasource-actions-wrapper"></div>' +
                 '</div>'
             ),
-            source2: template(
-                '<div class="source-select-wrapper">' +
-                    '<div class="source-select">' +
-                        // '<input type="radio" id="source-${type}" value="${type}">' +
-                        // '<label for="source-${type}">' +
-                        '<label>' +
-                            '<span></span>' +
-                            '${label}' +
-                        '</label>' +
-                        '<% if (obj.action) { %> ' +
-                            '<div class="action-link">' +
-                                '<div>&nbsp-&nbsp</div>' +
-                                '<a href="javascript:void(0);">${action}</a>' +
-                            '</div>' +
-                        '<% } %>' +
-                    '</div>' +
-                    '<div class="infolink icon-info" data-source="${type}" title="${tooltip}"></div>' +
-                '</div>'
-            ),
+            source2: ({ type, label, action, tooltip}) =>
+                `<div class="source-select-wrapper">
+                    <div class="source-select">
+                        <label>
+                            <span></span>
+                            ${label}
+                        </label>
+                        ${!action ? '' :
+                            `<div class="action-link">
+                                <div>&nbsp-&nbsp</div>
+                                <a href="javascript:void(0);">${action}</a>
+                            </div>`
+                        }
+                    </div>
+                    <div class="infolink icon-info" data-source="${type}" title="${tooltip}"></div>
+                </div>`,
             actions: ({ mapButton, fileButton }) =>
                 `<div class="datasource-action oskari-hidden">
                     <a href="javascript:void(0);">${mapButton}</a>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.js
@@ -45,14 +45,14 @@ Oskari.clazz.define('Oskari.coordinatetransformation.component.SourceSelect',
                 // '<div class="datasource-actions-wrapper"></div>' +
                 '</div>'
             ),
-            source2: ({ type, label, action, tooltip}) =>
+            source2: ({ type, label, action = '', tooltip }) =>
                 `<div class="source-select-wrapper">
                     <div class="source-select">
                         <label>
                             <span></span>
                             ${label}
                         </label>
-                        ${!action ? '' :
+                        ${action &&
                             `<div class="action-link">
                                 <div>&nbsp-&nbsp</div>
                                 <a href="javascript:void(0);">${action}</a>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -85,7 +85,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                     </div>
                     ${!obj.export
                         ? ''
-                        :`<div class="selection-wrapper lineSeparator">
+                        : `<div class="selection-wrapper lineSeparator">
                             <b class="title">${obj.lineSeparator}</b> 
                             <div class="settingsSelect">
                                 <select>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -1,5 +1,3 @@
-import { template } from 'lodash';
-
 Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
     function (helper, loc, type) {
         const me = this;
@@ -14,118 +12,117 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
         me.isFileInput = false;
         me.selections = {};
         me._template = {
-            settings: template('<div class="coordinatetransformation-file-form">' +
-                                    '<% if (obj.export === true) { %> ' +
-                                        '<div class="selection-wrapper fileName without-infolink">' +
-                                            '<b class="title">${fileName}</b>' +
-                                            '<input type="text">' +
-            // '<div class="infolink icon-info" data-selection="fileName"></div>' +
-                                        '</div>' +
-                                    '<% } else { %>' +
-                                        '<div class="selection-wrapper fileInput without-infolink"></div>' +
-                                        '<div class="selection-wrapper headerLineCount">' +
-                                            '<b class="title">${headerCount}</b>' +
-                                            '<input type="number" value="0" min="0" required> ' +
-                                            '<div class="infolink icon-info" data-selection="headerLineCount"></div>' +
-                                        '</div>' +
-                                    '<% } %> ' +
-                                    '<div class="selection-wrapper unitFormat">' +
-                                        '<b class="title">${units.label}</b> ' +
-                                        '<div class="settingsSelect">' +
-                                            '<select>' +
-                                                '<option value="degree" data-decimals="8">${units.degree}</option>' +
-                                                '<option value="gradian" data-decimals="8">${units.gradian}</option>' +
-                                                '<option value="radian" data-decimals="10">${units.radian}</option>' +
-                                                '<option value="DD" data-decimals="8">DD</option>' +
-                                                '<option value="DD MM SS" data-decimals="4">DD MM SS</option>' +
-                                                '<option value="DD MM" data-decimals="6">DD MM</option>' +
-                                                '<option value="DDMMSS" data-decimals="4">DDMMSS</option>' +
-                                                '<option value="DDMM" data-decimals="6">DDMM</option>' +
-                                            '</select>' +
-                                        '</div>' +
-                                        '<div class="infolink icon-info" data-selection="unitFormat"></div>' +
-                                    '</div>' +
-                                    '<% if (obj.export === true) { %> ' +
-                                        '<div class="selection-wrapper decimalPrecision">' +
-                                            '<b class="title">${decimalPrecision}</b>' +
-                                            '<div class="settingsSelect">' +
-                                            '<select>' +
-                                                '<option value="0">~1 m</option>' +
-                                                '<option value="1">~0.1 m</option>' +
-                                                '<option value="2">~1 cm</option>' +
-                                                '<option value="3" selected>~1 mm</option>' +
-                                                '<option value="4">~0.1 mm</option>' +
-                                            '</select>' +
-                                        '</div>' +
-                                            '<div class="infolink icon-info" data-selection="decimalPrecision"></div>' +
-                                        '</div>' +
-                                    '<% } %> ' +
-                                    '<div class="selection-wrapper decimalSeparator">' +
-                                        '<b class="title">${decimalSeparator}</b> ' +
-                                        '<div class="settingsSelect">' +
-                                            '<select>' +
-                                                '<option value="" selected disabled>${choose}</option>' +
-                                                '<option value=".">${delimeters.point}</option>' +
-                                                '<option value=",">${delimeters.comma}</option>' +
-                                            '</select>' +
-                                        '</div>' +
-                                        '<div class="infolink icon-info" data-selection="decimalSeparator"></div>' +
-                                    '</div>' +
-                                    '<div class="selection-wrapper coordinateSeparator">' +
-                                        '<b class="title">${coordinateSeparator}</b> ' +
-                                        '<div class="settingsSelect">' +
-                                            '<select>' +
-                                                '<option value="" selected disabled>${choose}</option>' +
-                                                '<option value="tab">${delimeters.tab}</option>' +
-                                                '<option value="space">${delimeters.space}</option>' +
-                                                '<option value="comma">${delimeters.comma}</option>' +
-                                                '<option value="semicolon">${delimeters.semicolon}</option>' +
-                                            '</select>' +
-                                        '</div>' +
-                                        '<div class="infolink icon-info" data-selection="coordinateSeparator"></div>' +
-                                    '</div>' +
-                                    '<% if (obj.export === true) { %> ' +
-                                        '<div class="selection-wrapper lineSeparator">' +
-                                            '<b class="title">${lineSeparator}</b> ' +
-                                            '<div class="settingsSelect">' +
-                                                '<select>' +
-                                                    '<option value="win">Windows / DOS</option>' +
-                                                    '<option value="unix">UNIX / Mac</option>' +
-                                                '</select>' +
-                                            '</div>' +
-                                            '<div class="infolink icon-info" data-selection="lineSeparator"></div>' +
-                                        '</div>' +
-                                    '<% } %> ' +
-                                    '<label class="lbl prefixId">' +
-                                        '<input class="chkbox" type="checkbox">' +
-                                        '<span></span>' +
-                                        '<div class="infolink icon-info" data-selection="prefixId"></div>' +
-                                    '</label>' +
-                                    '<label class="lbl reverseCoordinates">' +
-                                        '<input class="chkbox" type="checkbox">' +
-                                        '<span>${reverseCoords}</span>' +
-                                        '<div class="infolink icon-info" data-selection="reverseCoordinates"></div>' +
-                                    '</label> ' +
-                                    '<% if (obj.export === true) { %>' +
-                                        '<label class="lbl writeHeader">' +
-                                            '<input class="chkbox" type="checkbox">' +
-                                            '<span>${writeHeader}</span>' +
-                                            '<div class="infolink icon-info" data-selection="writeHeader"></div>' +
-                                        '</label>' +
-                                        '<label class="lbl lineEnds">' +
-                                            '<input class="chkbox" type="checkbox">' +
-                                            '<span>${lineEnds}</span>' +
-                                            '<div class="infolink icon-info" data-selection="lineEnds"></div>' +
-                                        '</label>' +
-                                        '<label class="lbl useCardinals">' +
-                                            '<input class="chkbox" type="checkbox">' +
-                                            '<span>${useCardinals}</span>' +
-                                            '<div class="infolink icon-info" data-selection="useCardinals"></div>' +
-                                        '</label>' +
-                                    '<% } %>' +
-                                '</div>' +
-                            '</div>'
-            )
+            settings: (obj) =>
+                `<div class="coordinatetransformation-file-form">
+                    ${obj.export ?
+                        `<div class="selection-wrapper fileName without-infolink">
+                            <b class="title">${obj.fileName}</b>
+                            <input type="text">
+                        </div>`
+                        :
+                        `<div class="selection-wrapper fileInput without-infolink"></div>
+                        <div class="selection-wrapper headerLineCount">
+                            <b class="title">${obj.headerCount}</b>
+                            <input type="number" value="0" min="0" required> 
+                            <div class="infolink icon-info" data-selection="headerLineCount"></div>
+                        </div>`
+                    }
+                    <div class="selection-wrapper unitFormat">
+                        <b class="title">${obj.units.label}</b> 
+                        <div class="settingsSelect">
+                            <select>
+                                <option value="degree" data-decimals="8">${obj.units.degree}</option>
+                                <option value="gradian" data-decimals="8">${obj.units.gradian}</option>
+                                <option value="radian" data-decimals="10">${obj.units.radian}</option>
+                                <option value="DD" data-decimals="8">DD</option>
+                                <option value="DD MM SS" data-decimals="4">DD MM SS</option>
+                                <option value="DD MM" data-decimals="6">DD MM</option>
+                                <option value="DDMMSS" data-decimals="4">DDMMSS</option>
+                                <option value="DDMM" data-decimals="6">DDMM</option>
+                            </select>
+                        </div>
+                        <div class="infolink icon-info" data-selection="unitFormat"></div>
+                    </div>
+                    ${!obj.export ? '' :
+                        `<div class="selection-wrapper decimalPrecision">
+                            <b class="title">${obj.decimalPrecision}</b>
+                            <div class="settingsSelect">
+                            <select>
+                                <option value="0">~1 m</option>
+                                <option value="1">~0.1 m</option>
+                                <option value="2">~1 cm</option>
+                                <option value="3" selected>~1 mm</option>
+                                <option value="4">~0.1 mm</option>
+                            </select>
+                        </div>
+                            <div class="infolink icon-info" data-selection="decimalPrecision"></div>
+                        </div>`
+                    }
+                    <div class="selection-wrapper decimalSeparator">
+                        <b class="title">${obj.decimalSeparator}</b> 
+                        <div class="settingsSelect">
+                            <select>
+                                <option value="" selected disabled>${obj.choose}</option>
+                                <option value=".">${obj.delimeters.point}</option>
+                                <option value=",">${obj.delimeters.comma}</option>
+                            </select>
+                        </div>
+                        <div class="infolink icon-info" data-selection="decimalSeparator"></div>
+                    </div>
+                    <div class="selection-wrapper coordinateSeparator">
+                        <b class="title">${obj.coordinateSeparator}</b> 
+                        <div class="settingsSelect">
+                            <select>
+                                <option value="" selected disabled>${obj.choose}</option>
+                                <option value="tab">${obj.delimeters.tab}</option>
+                                <option value="space">${obj.delimeters.space}</option>
+                                <option value="comma">${obj.delimeters.comma}</option>
+                                <option value="semicolon">${obj.delimeters.semicolon}</option>
+                            </select>
+                        </div>
+                        <div class="infolink icon-info" data-selection="coordinateSeparator"></div>
+                    </div>
+                    ${!obj.export ? '' :
+                        `<div class="selection-wrapper lineSeparator">
+                            <b class="title">${obj.lineSeparator}</b> 
+                            <div class="settingsSelect">
+                                <select>
+                                    <option value="win">Windows / DOS</option>
+                                    <option value="unix">UNIX / Mac</option>
+                                </select>
+                            </div>
+                            <div class="infolink icon-info" data-selection="lineSeparator"></div>
+                        </div>`
+                    }
+                    <label class="lbl prefixId">
+                        <input class="chkbox" type="checkbox">
+                        <span></span>
+                        <div class="infolink icon-info" data-selection="prefixId"></div>
+                    </label>
+                    <label class="lbl reverseCoordinates">
+                        <input class="chkbox" type="checkbox">
+                        <span>${obj.reverseCoords}</span>
+                        <div class="infolink icon-info" data-selection="reverseCoordinates"></div>
+                    </label> 
+                    ${!obj.export ? '' :
+                        `<label class="lbl writeHeader">
+                            <input class="chkbox" type="checkbox">
+                            <span>${obj.writeHeader}</span>
+                            <div class="infolink icon-info" data-selection="writeHeader"></div>
+                        </label>
+                        <label class="lbl lineEnds">
+                            <input class="chkbox" type="checkbox">
+                            <span>${obj.lineEnds}</span>
+                            <div class="infolink icon-info" data-selection="lineEnds"></div>
+                        </label>
+                        <label class="lbl useCardinals">
+                            <input class="chkbox" type="checkbox">
+                            <span>${obj.useCardinals}</span>
+                            <div class="infolink icon-info" data-selection="useCardinals"></div>
+                        </label>`
+                    }
+                </div>
+            </div`
         };
     }, {
         getElement: function () {
@@ -172,6 +169,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                 lineSeparator: this.loc('fileSettings.options.lineSeparator.label'),
                 choose: this.loc('fileSettings.options.choose')
             };
+            console.log(Object.keys(fileSettings));
             if (this.type === 'export') {
                 fileSettings.export = true;
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -11,16 +11,16 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
         me.metricSystem = false; // show degree systems options by default
         me.isFileInput = false;
         me.selections = {};
+        /* eslint-disable indent */
         me._template = {
             settings: (obj) =>
                 `<div class="coordinatetransformation-file-form">
-                    ${obj.export ?
-                        `<div class="selection-wrapper fileName without-infolink">
+                    ${obj.export
+                        ? `<div class="selection-wrapper fileName without-infolink">
                             <b class="title">${obj.fileName}</b>
                             <input type="text">
                         </div>`
-                        :
-                        `<div class="selection-wrapper fileInput without-infolink"></div>
+                        : `<div class="selection-wrapper fileInput without-infolink"></div>
                         <div class="selection-wrapper headerLineCount">
                             <b class="title">${obj.headerCount}</b>
                             <input type="number" value="0" min="0" required> 
@@ -43,8 +43,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                         </div>
                         <div class="infolink icon-info" data-selection="unitFormat"></div>
                     </div>
-                    ${!obj.export ? '' :
-                        `<div class="selection-wrapper decimalPrecision">
+                    ${!obj.export
+                        ? ''
+                        : `<div class="selection-wrapper decimalPrecision">
                             <b class="title">${obj.decimalPrecision}</b>
                             <div class="settingsSelect">
                             <select>
@@ -82,8 +83,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                         </div>
                         <div class="infolink icon-info" data-selection="coordinateSeparator"></div>
                     </div>
-                    ${!obj.export ? '' :
-                        `<div class="selection-wrapper lineSeparator">
+                    ${!obj.export
+                        ? ''
+                        :`<div class="selection-wrapper lineSeparator">
                             <b class="title">${obj.lineSeparator}</b> 
                             <div class="settingsSelect">
                                 <select>
@@ -104,8 +106,9 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                         <span>${obj.reverseCoords}</span>
                         <div class="infolink icon-info" data-selection="reverseCoordinates"></div>
                     </label> 
-                    ${!obj.export ? '' :
-                        `<label class="lbl writeHeader">
+                    ${!obj.export
+                        ? ''
+                        : `<label class="lbl writeHeader">
                             <input class="chkbox" type="checkbox">
                             <span>${obj.writeHeader}</span>
                             <div class="infolink icon-info" data-selection="writeHeader"></div>
@@ -124,6 +127,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                 </div>
             </div`
         };
+        /* eslint-enable indent */
     }, {
         getElement: function () {
             return this.element;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FileHandler.js
@@ -169,7 +169,6 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.FileHandler',
                 lineSeparator: this.loc('fileSettings.options.lineSeparator.label'),
                 choose: this.loc('fileSettings.options.choose')
             };
-            console.log(Object.keys(fileSettings));
             if (this.type === 'export') {
                 fileSettings.export = true;
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -70,7 +70,7 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
                     <input class="show" type="button" value="${show}"/>
                     <input class="export primary" type="button" value="${fileexport}"/>
                 </div>`,
-            filterSystems:({ title, systems, systemsInfo, epsg, epsgInfo }) =>
+            filterSystems: ({ title, systems, systemsInfo, epsg, epsgInfo }) =>
                 `<div class="systems-filter-wrapper">
                     <h4>${title}</h4>
                     <div class="coordinate-systems-filters">

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/transformation.js
@@ -1,5 +1,3 @@
-import { template } from 'lodash';
-
 Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
     function (instance, helper, dataHandler) {
         const me = this;
@@ -61,42 +59,37 @@ Oskari.clazz.define('Oskari.coordinatetransformation.view.transformation',
             divider: jQuery('<div class="auto-margin-divider"></div>'),
             // title: template('<h4 class="header"><%= title %></h4>'), //TODO move
             // TODO oskari btn
-            transformButton: template(
-                '<div class="transformation-button">' +
-                    '<input class="primary transform" type="button" value="<%= convert %> >>">' +
-                '</div>'
-            ),
+            transformButton: ({ convert }) =>
+                `<div class="transformation-button">
+                    <input class="primary transform" type="button" value="${convert}"/>
+                </div>`,
             // TODO oskari btn
-            utilRow: template(
-                '<div class="util-row-wrapper">' +
-                    '<input class="clear" type="button" value="<%= clear %> ">' +
-                    '<input class="show" type="button" value="<%= show %> ">' +
-                    '<input class="export primary" type="button" value="<%= fileexport %> ">' +
-                '</div>'
-            ),
-            filterSystems: template(
-                '<div class="systems-filter-wrapper">' +
-                    '<h4>${title}</h4>' +
-                    '<div class="coordinate-systems-filters">' +
-                        '<div class="source-select">' +
-                            '<input type="radio" id="filter-systems" name="filter-select" value="systems" checked>' +
-                            '<label for="filter-systems">' +
-                                '<span></span>' +
-                                '${systems}' +
-                            '</label>' +
-                // '<div class="infolink icon-info" data-source="systems" title="${systemsInfo}"></div>' +
-                        '</div>' +
-                        '<div class="source-select">' +
-                            '<input type="radio" id="filter-epsg" name="filter-select" value="epsg">' +
-                            '<label for="filter-epsg">' +
-                                '<span></span>' +
-                                '${epsg}' +
-                            '</label>' +
-                // '<div class="infolink icon-info" data-source="espg" title="${epsgInfo}"></div>' +
-                        '</div>' +
-                    '</div>' +
-                '</div>'
-            )
+            utilRow: ({ clear, show, fileexport }) =>
+                `<div class="util-row-wrapper">
+                    <input class="clear" type="button" value="${clear}"/>
+                    <input class="show" type="button" value="${show}"/>
+                    <input class="export primary" type="button" value="${fileexport}"/>
+                </div>`,
+            filterSystems:({ title, systems, systemsInfo, epsg, epsgInfo }) =>
+                `<div class="systems-filter-wrapper">
+                    <h4>${title}</h4>
+                    <div class="coordinate-systems-filters">
+                        <div class="source-select">
+                            <input type="radio" id="filter-systems" name="filter-select" value="systems" checked />
+                            <label for="filter-systems">
+                                <span></span>
+                                ${systems}
+                            </label>
+                        </div>
+                        <div class="source-select">
+                            <input type="radio" id="filter-epsg" name="filter-select" value="epsg"/>
+                            <label for="filter-epsg">
+                                <span></span>
+                                ${epsg}
+                            </label>
+                        </div>
+                    </div>
+                </div>`
         };
     }, {
         getName: function () {


### PR DESCRIPTION
refactor lodash template => function + template string literals => using it from code stays as is.

Used editors replace and had only quick check that everything looked same. For some templates used `obj.` (too lazy to check and copy-paste all variable names)

EDIT: for some reason eslint requires no indent after ? and : => disabled rule (I think its easier to read).