### PR TITLE
CoordTrans react - part 1

### DIFF
--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -47,7 +47,8 @@ import 'oskari-lazy-bundle?metadataflyout!oskari-frontend/bundles/catalogue/meta
 import 'oskari-lazy-bundle?metadatasearch!oskari-frontend/bundles/catalogue/metadatasearch';
 import 'oskari-lazy-bundle?terrain-profile!oskari-frontend-contrib/bundles/terrain-profile';
 
-import 'oskari-lazy-loader?coordinatetransformation!../../packages/paikkatietoikkuna/bundle/coordinatetransformation/bundle.js';
+import 'oskari-lazy-bundle?coordinatetransformation!../../bundles/paikkatietoikkuna/coordinatetransformation';
+// import 'oskari-lazy-loader?coordinatetransformation!../../packages/paikkatietoikkuna/bundle/coordinatetransformation/bundle.js';
 import 'oskari-lazy-loader?layerswipe!oskari-frontend/packages/mapping/ol/layerswipe/bundle.js';
 // added for mobile
 import 'oskari-lazy-loader?mobileuserguide!../../bundles/paikkatietoikkuna/mobileuserguide/bundle.js';

--- a/bundles/paikkatietoikkuna/coordinatetransformation/Flyout.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/Flyout.js
@@ -1,10 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { FlyoutContent } from './view/FlyoutContent';
+import { FlyoutWizard } from './view/FlyoutWizard';
+import { LocaleProvider, ThemeProvider } from 'oskari-ui/util';
+import { Spin, Button } from 'oskari-ui';
+import { ViewHandler } from './handler/ViewHandler';
+import { BUNDLE } from './constants';
+
 Oskari.clazz.define('Oskari.coordinatetransformation.Flyout',
 
     function (instance) {
         this.instance = instance;
-        this.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
+        this.loc = Oskari.getMsg.bind(null, BUNDLE);
         this.container = null;
-        this.flyout = null;
+        this.handler = null;
+        this.mode = null;
     }, {
         getName: function () {
             return 'Oskari.coordinatetransformation.Flyout';
@@ -12,21 +22,23 @@ Oskari.clazz.define('Oskari.coordinatetransformation.Flyout',
         getTitle: function () {
             return this.loc('flyout.title');
         },
-        getViews: function () {
-            return this.views;
-        },
-        setEl: function (el, flyout, width, height) {
-            this.container = jQuery(el[0]);
+        setEl: function (el, flyout) {
+            flyout.addClass(BUNDLE);
             this.flyout = flyout;
-            this.container.addClass('coordinatetransformation');
-            this.flyout.addClass('coordinatetransformation');
+            this.container = el[0];
+            this.container.classList.add(BUNDLE);
         },
-        createUi: function () {
-            this.instance.getViews().transformation.createUI(this.container);
+        getHandler: function () {
+            if (!this.handler) {
+                this.handler = new ViewHandler(this.instance, this.loc);
+                this.handler.addStateListener(() => this.lazyRender());
+            }
+            return this.handler;
         },
-        startPlugin: function () {
-            this.template = jQuery();
+        teardown: function () {
+            this.handler?.stop();
         },
+        // For some screen sizes css + media doesn't give enough space for content
         setContainerMaxHeight: function (mapHeight) {
             // calculate max-height based on map size
             const container = this.flyout.find('.oskari-flyoutcontentcontainer');
@@ -38,5 +50,35 @@ Oskari.clazz.define('Oskari.coordinatetransformation.Flyout',
             if (container.outerHeight(true) >= maxHeight) {
                 this.flyout.css('top', '0px');
             }
+        },
+        setMode: function (mode) {
+            this.mode = mode;
+            this.lazyRender();
+        },
+        lazyRender: function () {
+            const handler = this.getHandler();
+            if (!this.container || !handler ) {
+                return;
+            }
+            const state = handler.getState();
+            const content = (
+                <LocaleProvider value={{ bundleKey: BUNDLE }}>
+                    <ThemeProvider>
+                        <Spin spinning={state.loading}>
+                            { this.mode === 'wizard' && <FlyoutWizard state={state} controller={handler.getController()}/> }
+                            { this.mode === 'flyout' && <FlyoutContent {...state} controller={handler.getController()}/> }
+                            { !this.mode && (
+                                <div>
+                                    <Button onClick={() => this.setMode('wizard')}>Wizard</Button>
+                                    <Button onClick={() => this.setMode('flyout')}>Flyout</Button>
+                                </div>
+                            )}
+                        </Spin>
+                    </ThemeProvider>
+                </LocaleProvider>
+            );
+            ReactDOM.render(content, this.container);
         }
+    }, {
+        extend: ['Oskari.userinterface.extension.DefaultFlyout']
     });

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/ClearTableButton.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/ClearTableButton.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Message, Button, Confirm } from 'oskari-ui';
+
+export const ClearTableButton = ({ controller }) => (
+    <Confirm
+        title={<Message messageKey='flyout.coordinateTable.confirmClear'/>}
+        onConfirm={() => controller.clearTables()}>
+        <Button>
+            <Message messageKey='flyout.coordinateTable.clearTables'/>
+        </Button>
+    </Confirm>
+);
+
+ClearTableButton.propTypes = {
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/ComponentLabel.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/ComponentLabel.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Label, Message} from 'oskari-ui';
+
+const StyledLabel = styled(Label)`
+    font-weight: bold;
+`;
+const Extra = styled.span`
+    float: right;
+`;
+
+export const ComponentLabel  = ({ label, children }) => (
+    <StyledLabel>
+        <Message messageKey={label} />
+        <Extra>
+            { children }
+        </Extra>
+    </StyledLabel>
+);
+
+ComponentLabel.propTypes = {
+    label: PropTypes.string.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, TextInput } from 'oskari-ui';
+import { ComponentLabel } from './ComponentLabel';
+import { Table } from 'oskari-ui/components/Table';
+import { SRS, SYSTEM } from '../constants';
+import { getDimension } from '../helper';
+
+const COLUMNS = ['x', 'y', 'z'];
+
+const StyledTable = styled(Table)`
+    td.ant-table-cell {
+        ${props => props.$editable && 'padding: 0 !important;'}
+        height: 24px;
+        font-size: 12px;
+    }
+`;
+const StyledInput = styled(TextInput)`
+    border: none;
+    font-size: 12px;
+`;
+const Count = styled.span`
+    float: right;
+`;
+
+const Content = styled.div`
+
+`;
+
+// TODO: remove ?
+const Cell = ({ value, item, onChange }) => {
+    return (
+        <TextInput
+            value={value}
+            onChange={(e) => onChange(item.key, e.target.value)}
+        />
+    );
+};
+
+const getEmptyArray = size => [...Array(size)].map(() => ({}));
+
+const getColumn = (column, lonFirst, unit, dimension, editable, controller) => {
+    let tileColumn = column;
+    if (lonFirst) {
+        if (column === 'x') {
+            tileColumn = 'y';
+        } else if (column === 'y') {
+            tileColumn = 'x';
+        }
+    }
+    const props = {
+        title: <Message messageKey={`flyout.coordinateTable.${unit}.${tileColumn}`} />,
+        dataIndex: column,
+        width: dimension === 2 ? 180 : 120
+    };
+    const onEdit = (index, item, value) => {
+        if (value.includes('\t')) {
+            controller.pasteCoordinates(value);
+        } else {
+            controller.updateCoordinate(index, { ...item, [column]:  value });
+        }
+    };
+    // TODO: some styling for invalid coordinate??
+    if (editable) {
+        props.render = (value, item, index) =>
+            <StyledInput size='small' value={value} onChange={e => onEdit(index, item, e.target.value)} onBlur={() => controller.parseInputCoordinate(index, column)} />
+    }
+    return props;
+};
+
+export const InputCoordinates = ({ source, coordinates, inputSrs, inputHeightSrs, controller}) =>
+    <CoordinateTable type='input' coordinates={coordinates} srs={inputSrs} heightSrs={inputHeightSrs} controller={controller} editable={source === 'table'} />;
+
+export const OutputCoordinates = ({ results, outputSrs, outputHeightSrs, controller}) =>
+    <CoordinateTable type='output' coordinates={results} srs={outputSrs} heightSrs={outputHeightSrs} controller={controller} />;
+
+export const CoordinateTable = ({ type, coordinates, srs, heightSrs, controller, editable }) => {
+    // TODO: internal state for pagination
+    const { system, lonFirst } = SRS.find(s => s.value === srs) || {};
+    const { unit = 'metric' } = SYSTEM.find(s => s.value === system) || {};
+    const dimension = getDimension(srs, heightSrs);
+    const columns = COLUMNS.slice(0, dimension).map(col => getColumn(col, lonFirst, unit, dimension, editable, controller));
+    // TODO: assumes pagination page size 10
+    const dataSource = [...coordinates, ...getEmptyArray(10 - coordinates.length % 10)]; // .map((a,key) => ({...a, key }));
+    return (
+        <Content>
+            <ComponentLabel label={`flyout.coordinateTable.${type}`}>
+                {coordinates.filter(coord => !coord.invalid).length + ' '}
+                <Message messageKey='flyout.coordinateTable.rows' />
+            </ComponentLabel>
+            <StyledTable bordered
+                $editable={editable}
+                columns={columns}
+                dataSource={dataSource}
+                pagination={{ hideOnSinglePage: true }}/>
+        </Content>
+    );
+};
+
+CoordinateTable.propTypes = {
+    coordinates: PropTypes.array.isRequired,
+    srs: PropTypes.string,
+    type: PropTypes.string.isRequired,
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/FileSettings.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/FileSettings.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Message, Checkbox } from 'oskari-ui';
+import { FileInput } from 'oskari-ui/components/FileInput';
+import { LabeledSelect, LabeledInput } from './Lableled';
+import { InfoIcon } from 'oskari-ui/components/icons';
+import { SEPARATORS, DECIMAL, DEGREE } from '../constants';
+import { isDegreeSystem } from '../helper';
+
+const FILE_INPUT_PROPS = {
+    multiple: false,
+    allowedTypes: ['text/plain', 'text/csv'],
+    allowedExtensions: ['txt', 'csv'],
+    maxSize: 50
+};
+
+const OPTIONS = {
+    importSelect: ['decimalSeparator', 'coordinateSeparator'],
+    importCheckbox: ['prefixId', 'axisFlip'],
+    exportSelect: ['decimalCount', 'decimalSeparator', 'coordinateSeparator', 'lineSeparator'],
+    exportCheckbox: ['prefixId', 'axisFlip', 'writeHeader', 'writeLineEndings', 'writeCardinals'],
+    options: {...SEPARATORS, decimalCount: DECIMAL, unit: DEGREE }
+};
+
+const IMPORT = ['headerLineCount', 'prefixId', 'axisFlip'];
+
+const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 1em;
+`;
+const showDegreeUnit = srs => {
+    if (!srs) {
+        return true;
+    }
+    return isDegreeSystem(srs);
+};
+
+const CheckboxOption = ({id, checked, onChange, controller}) => (
+    <Wrapper>
+        <Checkbox checked={checked} onChange={evt => onChange(id, evt.target.checked)}>
+            <Message messageKey={`fileSettings.options.${id}`} />
+        </Checkbox>
+        <span onClick={() => controller.showInfo(id)}>
+            <InfoIcon title={<Message messageKey={`infoPopup.${id}.title`}/>}/>
+        </span>
+    </Wrapper>
+);
+
+const SelectOption = ({id, value, onChange, controller}) =>
+    <LabeledSelect localize mandatory label={`fileSettings.options.${id}`} info={id} value={value} options={OPTIONS.options[id]} onChange={value => onChange(id, value)} controller={controller}/>
+
+export const ImportFile = ({ import: values, inputSrs, files, controller }) => {
+    const onChange = (key, value) => controller.setFileSetting('import', key, value);
+    return (
+        <Content>
+            <FileInput mandatory onFiles={controller.setFiles} files={files} { ...FILE_INPUT_PROPS } />
+            <LabeledInput number min={0} label='fileSettings.options.headerLineCount' value={values.headerLineCount} onChange={value => onChange('headerLineCount', value)} controller={controller}/>
+            { showDegreeUnit(inputSrs) && <SelectOption id='unit' controller={controller} onChange={onChange} value={values.unit}/> }
+            { OPTIONS.importSelect.map(id => <SelectOption key={id} id={id} controller={controller} onChange={onChange} value={values[id]}/>)}
+            { OPTIONS.importCheckbox.map(id => <CheckboxOption key={id} id={id} controller={controller} onChange={onChange} checked={values[id]}/>)}
+        </Content>
+    );
+};
+
+export const ExportFile = ({ export: values, outputSrs, controller }) => {
+    const onChange = (key, value) => controller.setFileSetting('export', key, value);
+    return (
+        <Content>
+            <LabeledInput label='fileSettings.export.fileName' value={values.fileName} onChange={evt => onChange('fileName', evt.target.value)} controller={controller}/>
+            { showDegreeUnit(outputSrs) && <SelectOption id='unit' controller={controller} onChange={onChange} value={values.unit}/> }
+            { OPTIONS.exportSelect.map(id => <SelectOption key={id} id={id} controller={controller} onChange={onChange} value={values[id]}/>)}
+            { OPTIONS.exportCheckbox.map(id => <CheckboxOption key={id} id={id} controller={controller} onChange={onChange} checked={values[id]}/>)}
+        </Content>
+    );
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/Lableled.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/Lableled.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Label, Select, TextInput, NumberInput } from 'oskari-ui';
+import { InfoIcon, MandatoryIcon } from 'oskari-ui/components/icons';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-flow: ${props => props.$block ? 'column' : 'row'} nowrap;
+    gap: ${props => props.$block ? 0 : '1em'};
+`;
+const StyledLabel = styled(Label)`
+    width: ${props => props.$block ? 360 : 160}px;
+`;
+const StyledSelect = styled(Select)`
+    width: 200px;
+`;
+const StyledTextInput = styled(TextInput)`
+    width: 200px;
+`;
+const StyledNumberInput = styled(NumberInput)`
+    width: 200px;
+`;
+
+const phMandatory = <Message messageKey='actions.select' />
+const phOptional = <Message messageKey='flyout.coordinateSystem.noFilter' />
+const getLocalized = options => options.map(opt => opt.label ? opt : ({ ...opt, label: <Message messageKey={opt.loc} messageArgs={opt.args} /> }));
+
+const Info = ({ info, controller }) => (
+    <span onClick={() => controller.showInfo(info)}>
+        <InfoIcon space={false} title={<Message messageKey={`infoPopup.${info}.title`}/>}/>
+    </span>
+);
+
+export const LabeledSelect = ({ 
+    label,
+    block,
+    value,
+    info,
+    mandatory,
+    localize,
+    options,
+    controller,
+    placeholder = mandatory ? phMandatory : phOptional,
+    ...restForSelect
+}) => (
+    <Wrapper $block={block}>
+        <StyledLabel $block={block}>
+            <Message messageKey={label} />
+            &nbsp;
+            { mandatory &&  <MandatoryIcon isValid={value === 0 || !!value} /> }
+            &nbsp;
+            { (info && block) && <Info info={info} controller={controller}/> }
+        </StyledLabel>
+        <StyledSelect
+            { ...restForSelect }
+            value={value}
+            allowClear={!mandatory}
+            options={localize ? getLocalized(options) : options}
+            placeholder={placeholder}/>
+        { (info && !block) && <Info info={info} controller={controller}/> }
+    </Wrapper>
+);
+
+LabeledSelect.propTypes = {
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    mandatory: PropTypes.bool,
+    localize: PropTypes.bool,
+    info: PropTypes.string,
+    options: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired
+};
+
+export const LabeledInput = ({ label, mandatory, value, info, number, placeholder, controller, ...restForInput }) => {
+    const Input = number ? StyledNumberInput : StyledTextInput;
+    const isValid = !mandatory || number || ( value && value.trim().length > 0 );
+    return (
+        <Wrapper>
+            <StyledLabel>
+                <Message messageKey={label} />
+                &nbsp;
+                { mandatory &&  <MandatoryIcon isValid={isValid} /> }
+            </StyledLabel>
+            <Input
+                { ...restForInput }
+                value={value}
+                placeholder={placeholder}/>
+            { info && <Info info={info} controller={controller}/> }
+        </Wrapper>
+    );
+};
+LabeledInput.propTypes = {
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    number: PropTypes.bool,
+    localize: PropTypes.bool,
+    info: PropTypes.string,
+    onChange: PropTypes.func.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/MapSelect.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/MapSelect.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Radio } from 'oskari-ui';
+import { BUNDLE, MAP } from '../constants';
+
+const Content = styled.div`
+    width: 800px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
+const radioStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8
+};
+// style={radioStyle}
+export const MapSelect = ({ controller }) => {
+    const [value, setValue] = useState(MAP.ADD);
+    const onRadio = value => {
+        setValue(value);
+        controller.onAction(value);
+    };
+    const options = Object.values(MAP).map(value => ({ value, label: <Message messageKey={`mapMarkers.select.${value}`} bundleKey={BUNDLE} />}));
+    return (
+        <Content>
+            <Message messageKey='mapMarkers.select.info' bundleKey={BUNDLE} />
+            <Radio.Group
+                value={value}
+                onChange={evt => onRadio(evt.target.value)}
+                options={options}/>
+        </Content>
+    );
+};
+
+MapSelect.propTypes = {
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SourceSelect.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Radio, Button } from 'oskari-ui';
+import { ComponentLabel } from './ComponentLabel';
+import { InfoIcon } from 'oskari-ui/components/icons';
+import { SOURCE } from '../constants';
+
+const Content = styled.div`
+`;
+
+const style = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8
+};
+const Option = ({ id, value, controller }) => {
+    const showAction = id === value && id !== 'table';
+    const onClick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        controller.showInfo(id);
+    };
+    return (
+        <Content>
+            <Message messageKey={`dataSource.${id}.label`} />
+            { showAction &&
+                <Button type='link' onClick={() => controller.onAction(id)}>
+                    <Message messageKey={`dataSource.${id}.action`} />
+                </Button>
+            }
+            <span onClick={onClick}>
+                <InfoIcon title={<Message messageKey={`dataSource.${id}.info`} />} />
+            </span>
+        </Content>
+    );
+};
+
+// TODO: wrap confirm or confirm popup to handler
+export const SourceSelect = ({ value, controller }) => {
+    const onSource = source => {
+        controller.setSource(source);
+        controller.onAction(source)
+    };
+    return(
+        <Content>
+            <ComponentLabel label='dataSource.title'/>
+            <Radio.Group
+                value={value}
+                style={style}
+                onChange={evt => onSource(evt.target.value)}
+                options={SOURCE.map(id => ({label: <Option id={id} value={value} controller={controller}/>, value: id }))}/>
+        </Content>
+    );
+};
+
+SourceSelect.propTypes = {
+    value: PropTypes.string,
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SrsSelect.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SrsSelect.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message } from 'oskari-ui';
+import { LabeledSelect } from './Lableled';
+import { ComponentLabel } from './ComponentLabel';
+import { DATUM, SYSTEM, PROJECTION, SRS, SRS_H } from '../constants';
+import { getDimension } from '../helper';
+
+const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+`;
+const SelectWrapper = styled.div`
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 1em;
+`;
+
+export const InputSrs = ({ inputSrs, inputHeightSrs, controller }) => 
+    <SrsSelect type='input' srs={inputSrs} heightSrs={inputHeightSrs} controller={controller} />;
+
+export const OutputSrs = ({ outputSrs, outputHeightSrs, controller }) => 
+    <SrsSelect type='output' srs={outputSrs} heightSrs={outputHeightSrs} controller={controller} />;
+
+export const SrsSelect = ({ srs, heightSrs, type, minimal, controller }) => {
+    const [searchVisible, setSearchVisible] = useState(false);
+    const heightDisabled = getDimension(srs) === 3;
+    const searchPH = <Message messageKey='flyout.coordinateSystem.epsgSearch.label' />
+    // TODO: disable or hide height on 3D
+    if (minimal) {
+        return (
+            <Content>
+                <ComponentLabel label={`flyout.coordinateSystem.${type}.title`}/>
+                <LabeledSelect block mandatory localize showSearch placeholder={searchPH} filterOption={filter} label='flyout.coordinateSystem.geodeticCoordinateSystem.label' info='geodeticCoordinateSystem' value={srs} options={SRS} onChange={val => controller.setSrs(type, val)} controller={controller}/>
+                <LabeledSelect block label='flyout.coordinateSystem.heightSystem.label' value={heightSrs} disabled={heightDisabled} info='heightSystem' options={SRS_H} onChange={val => controller.setSrs(`${type}Height`, val)} controller={controller}/>
+            </Content>
+        );
+    }
+    const [datum, setDatum] = useState(null);
+    const [system, setSystem] = useState(null);
+    const [projection, setProjection] = useState(null);
+    
+    const onSystem = system => {
+        if (system !== 'COORD_PROJ_2D') {
+            // reset hidden select
+            setProjection(null);
+        }
+        setSystem(system);
+    };
+    const srsOptions = SRS.filter(srs => {
+        if (datum && datum !== srs.datum) {
+            return false;
+        }
+        if (system && system !== srs.system) {
+            return false;
+        }
+        if (projection && projection !== srs.projection) {
+            return false;
+        }
+        return true;
+    });
+    // TODO: SYSTEM showProjection, helper showProjection ??
+    const filter = (input, {label, value, reversedEpsg}) => `${label} ${value} ${reversedEpsg}`.toLowerCase().includes(input.toLowerCase());
+    return (
+        <Content>
+            <ComponentLabel label={`flyout.coordinateSystem.${type}.title`}/>
+            <LabeledSelect label='flyout.coordinateSystem.geodeticDatum.label' info='geodeticDatum' value={datum} options={DATUM} onChange={setDatum} controller={controller}/>
+            <LabeledSelect localize label='flyout.coordinateSystem.coordinateSystem.label' info='coordinateSystem' value={system} options={SYSTEM} onChange={onSystem} controller={controller}/>
+            { system === 'COORD_PROJ_2D' && <LabeledSelect label='flyout.coordinateSystem.mapProjection.label' info='mapProjection' value={projection} options={PROJECTION} onChange={setProjection} controller={controller}/> }
+            <LabeledSelect mandatory localize showSearch filterOption={filter} label='flyout.coordinateSystem.geodeticCoordinateSystem.label' info='geodeticCoordinateSystem' value={srs} options={srsOptions} onChange={val => controller.setSrs(type, val)} controller={controller}/>
+            <LabeledSelect label='flyout.coordinateSystem.heightSystem.label' value={heightSrs} disabled={heightDisabled} info='heightSystem' options={SRS_H} onChange={val => controller.setSrs(`${type}Height`, val)} controller={controller}/>
+        </Content>
+    );
+};
+
+SrsSelect.propTypes = {
+    srs: PropTypes.string,
+    minimal: PropTypes.bool,
+    heightSrs: PropTypes.string,
+    type: PropTypes.string.isRequired,
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/constants.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/constants.js
@@ -1,0 +1,423 @@
+export const BUNDLE = 'coordinatetransformation';
+export const WATCH_JOB = 'CoordinateTransformJob';
+export const WATCH_URL = '/coordinatetransform/watch/';
+export const ID_PREFIX = 'coord_marker_';
+// TODO: or enums?
+export const SOURCE = ['table', 'file', 'map'];
+export const TRANSFORM = ['A2A', 'F2A', 'F2R' , 'F2F', 'A2F'];
+export const MAP = {
+    ADD: 'add',
+    REMOVE: 'remove'
+};
+
+export const MARKER = {
+    colors: {
+        new: '#ff0000',
+        old: '#00ff00'
+    },
+    shape: 3,
+    size: 3
+};
+
+export const FILE_DEFAULTS = {
+    import: {
+        headerLineCount: 0,
+        unit: 'degree'
+    },
+    export: {
+        unit: 'degree',
+        decimalCount: 3,
+        decimalSeparator: Oskari.getDecimalSeparator(),
+        coordinateSeparator: 'semicolon',
+        lineSeparator: 'win'
+    }
+}
+const closestZoom = 6;
+
+export const SEPARATORS = {
+    lineSeparator: [
+        { label: 'Windows / DOS', value: 'win' },
+        { label: 'UNIX / Mac', value: 'unix' }
+    ],
+    coordinateSeparator: [
+        { loc: 'fileSettings.options.delimeters.tab', value: 'tab' },
+        { loc: 'fileSettings.options.delimeters.space', value: 'space' },
+        { loc: 'fileSettings.options.delimeters.comma', value: 'comma' },
+        { loc: 'fileSettings.options.delimeters.semicolon', value: 'semicolon' }
+    ],
+    decimalSeparator: [
+        { loc: 'fileSettings.options.delimeters.point', value: '.' },
+        { loc: 'fileSettings.options.delimeters.comma', value: ',' }
+    ]
+};
+export const DECIMAL = [
+    { label: '~1 m', value: 0 },
+    { label: '~0.1 m', value: 1 },
+    { label: '~1 cm', value: 2 },
+    { label: '~1 mm', value: 3 },
+    { label: '~0.1 mm', value: 4 }
+];
+
+export const DEGREE = [
+    { loc: 'fileSettings.options.degreeFormat.degree', value: 'degree', decimals: 8 },
+    { loc: 'fileSettings.options.degreeFormat.gradian', value: 'gradian', decimals: 8 },
+    { loc: 'fileSettings.options.degreeFormat.radian', value: 'radian', decimals: 10 },
+    { label: 'DD', value: 'DD', decimals: 8 },
+    { label: 'DD MM', value: 'DD MM', decimals: 6 },
+    { label: 'DD MM SS', value: 'DD MM SS', decimals: 4 },
+    { label: 'DDMM', value: 'DDMM', decimals: 6},
+    { label: 'DDMMSS', value: 'DDMMSS', decimals: 4 }
+];
+export const DEGREE_DECIMALS = DEGREE.find(d => d.value === 'degree')?.decimals;
+export const DMS = ['\u00B0', '\u0027', '\u0022'];
+
+export const DATUM = [
+    {
+        value: 'DATUM_KKJ',
+        label: 'KKJ',
+        cls: 'DATUM_KKJ DATUM_EUREF-FIN'
+    }, {
+        value: 'DATUM_EUREF-FIN',
+        label: 'EUREF-FIN',
+        cls: 'DATUM_KKJ DATUM_EUREF-FIN'
+    }
+];
+export const SYSTEM = [
+    {
+        value: 'COORD_PROJ_2D',
+        loc: 'flyout.coordinateSystem.coordinateSystem.proj2D',
+        cls: 'DATUM_KKJ DATUM_EUREF-FIN',
+        unit: 'metric',
+        dimension: 2
+    }, {
+        value: 'COORD_PROJ_3D',
+        loc: 'flyout.coordinateSystem.coordinateSystem.proj3D',
+        cls: 'DATUM_EUREF-FIN',
+        unit: 'geocentric',
+        dimension: 3
+    }, {
+        value: 'COORD_GEOG_2D',
+        loc: 'flyout.coordinateSystem.coordinateSystem.geo2D',
+        cls: 'DATUM_EUREF-FIN DATUM_KKJ',
+        unit: 'degree',
+        dimension: 2
+    }, {
+        value: 'COORD_GEOG_3D',
+        loc: 'flyout.coordinateSystem.coordinateSystem.geo3D',
+        cls: 'DATUM_EUREF-FIN',
+        unit: 'degree3D',
+        dimension: 3
+    }
+
+];
+export const PROJECTION = [
+    {
+        value: 'PROJECTION_KKJ',
+        label: 'KKJ',
+        cls: 'DATUM_KKJ'
+    }, {
+        value: 'PROJECTION_TM',
+        label: 'Transversal Mercator',
+        cls: 'DATUM_EUREF-FIN'
+    }, {
+        value: 'PROJECTION_GK',
+        label: 'Gauss-Kruger',
+        cls: 'DATUM_EUREF-FIN'
+    }, {
+        value: 'PROJECTION_LAEA',
+        label: 'Lambert Azimuthal Equal Area',
+        cls: 'DATUM_EUREF-FIN'
+    }, {
+        value: 'PROJECTION_LCC',
+        label: 'Lambert Conic Conformal',
+        cls: 'DATUM_EUREF-FIN'
+    }
+
+];
+// bounds:[minx, miny, maxx, maxy], lonFirst: true -> lonlat, EN, XY
+export const SRS = [
+    // newer GK EPSG-codes which have false easting 500000 prefixed with zone number -> GK19 19500000
+    // replacedEpsg is the old one, which have always false easting 500000
+    {
+        value: 'EPSG:3873',
+        label: 'ETRS-GK19',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [16136220.08, 4245436.94, 19729336.74, 9392386.51],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3126'
+    }, {
+        value: 'EPSG:3874',
+        label: 'ETRS-GK20',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [17036139.71, 4284384.64, 20718673.04, 9388493.84],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3127'
+    }, {
+        value: 'EPSG:3875',
+        label: 'ETRS-GK21',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [17935765.83, 4324906.92, 21707943.90, 9384787.32],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3128'
+    }, {
+        value: 'EPSG:3876',
+        label: 'ETRS-GK22',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [18835101.07, 4367049.45, 22697152.55, 9381268.03],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3129'
+    }, {
+        value: 'EPSG:3877',
+        label: 'ETRS-GK23',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [19734149.31, 4410859.98, 23686302.23, 9377936.99],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3130'
+    }, {
+        value: 'EPSG:3878',
+        label: 'ETRS-GK24',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [20632915.73, 4456388.39, 24675396.21, 9374795.15],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3131'
+    }, {
+        value: 'EPSG:3879',
+        label: 'ETRS-GK25',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [21531406.93, 4503686.78, 25664437.76, 9371843.41],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3132'
+    }, {
+        value: 'EPSG:3880',
+        label: 'ETRS-GK26',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [22429630.98, 4552809.52, 26653430.17, 9369082.63],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3133'
+    }, {
+        value: 'EPSG:3881',
+        label: 'ETRS-GK27',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [23327597.57, 4603813.37, 27642376.73, 9366513.60],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3134'
+    }, {
+        value: 'EPSG:3882',
+        label: 'ETRS-GK28',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [24225318.05, 4656757.53, 28631280.76, 9364137.06],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3135'
+    }, {
+        value: 'EPSG:3883',
+        label: 'ETRS-GK29',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [25122805.55, 4711703.72, 29620145.58, 9361953.68],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3136'
+    }, {
+        value: 'EPSG:3884',
+        label: 'ETRS-GK30',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [26020075.09, 4768716.31, 30608974.53, 9359964.10],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3137'
+    }, {
+        value: 'EPSG:3885',
+        label: 'ETRS-GK31',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_GK',
+        system: 'COORD_PROJ_2D',
+        bounds: [26917143.71, 4827862.39, 31597770.94, 9358168.88],
+        lonFirst: false,
+        replacedEpsg: 'EPSG:3138'
+    }, {
+        value: 'EPSG:3035',
+        label: 'ETRS-LAEA',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_LAEA',
+        system: 'COORD_PROJ_2D',
+        bounds: [1896628.62, 1507846.05, 4656644.57, 6827128.02],
+        lonFirst: false
+    }, {
+        value: 'EPSG:3034',
+        label: 'ETRS-LCC',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_LCC',
+        system: 'COORD_PROJ_2D',
+        bounds: [1584884.54, 1150546.94, 4435373.08, 6675249.46],
+        lonFirst: false
+    }, {
+        value: 'EPSG:3046',
+        label: 'ETRS-TM34',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_TM',
+        system: 'COORD_PROJ_2D',
+        bounds: [-3062460.04, 4323108.17, 707860.72, 9381033.40],
+        lonFirst: false,
+        reversedEpsg: 'EPSG:25834'
+    }, {
+        value: 'EPSG:3047',
+        label: 'ETRS-TM35',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_TM',
+        system: 'COORD_PROJ_2D',
+        bounds: [-3669433.90, 4601644.86, 642319.78, 9362767.00],
+        lonFirst: false,
+        reversedEpsg: 'EPSG:25835'
+    }, {
+        value: 'EPSG:3048',
+        label: 'ETRS-TM36',
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_TM',
+        system: 'COORD_PROJ_2D',
+        bounds: [-4283197.87, 4949558.27, 575249.45, 9351421.46],
+        lonFirst: false,
+        reversedEpsg: 'EPSG:25836'
+    }, {
+        value: 'EPSG:3067',
+        label: 'ETRS-TM35FIN', // (E,N)
+        datum: 'DATUM_EUREF-FIN',
+        projection: 'PROJECTION_TM',
+        system: 'COORD_PROJ_2D',
+        bounds: [-3669433.90, 4601644.86, 642319.78, 9362767.00],
+        lonFirst: true,
+        reversedEpsg: 'EPSG:5048'
+    }, {
+        value: 'EPSG:4258',
+        label: 'EUREF-FIN-GRS80',
+        datum: 'DATUM_EUREF-FIN',
+        projection: '',
+        system: 'COORD_GEOG_2D',
+        bounds: [-16.1, 32.88, 39.65, 84.17],
+        lonFirst: false
+    }, {
+        value: 'EPSG:4937',
+        label: 'EUREF-FIN-GRS80h',
+        datum: 'DATUM_EUREF-FIN',
+        projection: '',
+        system: 'COORD_GEOG_3D',
+        bounds: [-16.1, 32.88, 39.65, 84.17],
+        lonFirst: false
+    }, {
+        value: 'EPSG:4936',
+        label: 'EUREF-FIN-XYZ',
+        datum: 'DATUM_EUREF-FIN',
+        projection: '',
+        system: 'COORD_PROJ_3D',
+        bounds: [5151420.52, -1486881.13, 500495.11, 414781.77],
+        lonFirst: true
+    }, {
+        value: 'EPSG:3386',
+        loc: 'flyout.coordinateSystem.geodeticCoordinateSystem.kkj',
+        args: { zone: 0 },
+        datum: 'DATUM_KKJ',
+        projection: 'PROJECTION_KKJ',
+        system: 'COORD_PROJ_2D',
+        bounds: [569217.09, 6663791.81, 583029.96, 6693054.88],
+        lonFirst: false
+    }, {
+        value: 'EPSG:2391',
+        loc: 'flyout.coordinateSystem.geodeticCoordinateSystem.kkj',
+        args: { zone: 1 },
+        datum: 'DATUM_KKJ',
+        projection: 'PROJECTION_KKJ',
+        system: 'COORD_PROJ_2D',
+        bounds: [1415885.57, 6628437.53, 1559300.06, 7695112.84],
+        lonFirst: false
+    }, {
+        value: 'EPSG:2392',
+        loc: 'flyout.coordinateSystem.geodeticCoordinateSystem.kkj',
+        args: { zone: 2 },
+        datum: 'DATUM_KKJ',
+        projection: 'PROJECTION_KKJ',
+        system: 'COORD_PROJ_2D',
+        bounds: [2415851.96, 6627314.46, 2560464.61, 7647148.92],
+        lonFirst: false
+    }, {
+        value: 'EPSG:2393',
+        loc: 'flyout.coordinateSystem.geodeticCoordinateSystem.ykj',
+        datum: 'DATUM_KKJ',
+        projection: 'PROJECTION_KKJ',
+        system: 'COORD_PROJ_2D',
+        bounds: [3064557.21, 6651895.29, 3674549.99, 7785726.70],
+        lonFirst: false
+    }, {
+        value: 'EPSG:2394',
+        loc: 'flyout.coordinateSystem.geodeticCoordinateSystem.kkj', 
+        args: { zone: 4 },
+        datum: 'DATUM_KKJ',
+        projection: 'PROJECTION_KKJ',
+        system: 'COORD_PROJ_2D',
+        bounds: [4418851.11, 6759862.03, 4557959.34, 7748619.72],
+        lonFirst: false
+    }, {
+        value: 'EPSG:3387',
+        loc: 'flyout.coordinateSystem.geodeticCoordinateSystem.kkj',
+        args: { zone: 5 },
+        datum: 'DATUM_KKJ',
+        projection: 'PROJECTION_KKJ',
+        system: 'COORD_PROJ_2D',
+        bounds: [5423705.81, 6970442.95, 5428707.25, 6989284.23],
+        lonFirst: false
+    }, { 
+        value:'EPSG:4123', // KKJ_GEO
+        label: 'KKJ-Hayford',
+        datum: 'DATUM_KKJ',
+        projection: '',
+        system: 'COORD_GEOG_2D',
+        bounds: [19.24, 59.75, 31.59, 70.09],
+        lonFirst: false
+    }
+];
+export const SRS_H = [
+    {
+        value: 'EPSG:3900',
+        label: 'N2000',
+        cls: 'DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT'
+    }, {
+        value: 'EPSG:5717',
+        label: 'N60',
+        cls: 'DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT'
+    }, { 
+        value: 'EPSG:8675',
+        label: 'N43',
+        cls: 'DATUM_KKJ DATUM_EUREF-FIN DATUM_DEFAULT'
+    }
+];
+
+
+const createCls = (json) => {
+    Object.keys(json).forEach(function (key) {
+        const geoCoord = json[key];
+        if (key === 'DEFAULT') {
+            geoCoord.cls = '';
+        } else {
+            geoCoord.cls = geoCoord.datum + ' ' + geoCoord.proj + ' ' + geoCoord.coord;
+        }
+    });
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -1,0 +1,389 @@
+import { StateHandler, controllerMixin, Messaging } from 'oskari-ui/util';
+import { showInfoPopup } from '../view/InfoPopup';
+import { showFilePopup } from '../view/FilePopup';
+import { showMapSelectPopup, showMapPreviewPopup } from '../view/MapPopup';
+import { SOURCE, MAP, WATCH_JOB, WATCH_URL, TRANSFORM, FILE_DEFAULTS } from '../constants';
+import { stateToPTIArray, loadFile, validateTransform, validateFileSettings, parseCoordinateValue } from '../helper';
+
+const getInitialState = () => ({
+    loading: false,
+    source: SOURCE[0],
+    transformType: null, // ??
+    inputSrs: null, // input, output (srs, height)
+    outputSrs: null,
+    inputHeightSrs: null,
+    outputHeightSrs: null,
+    files: [],
+    import: {...FILE_DEFAULTS.import},
+    export: {...FILE_DEFAULTS.export},
+    coordinates: [],
+    results: []
+});
+
+class UIHandler extends StateHandler {
+    constructor (instance) {
+        super();
+        this.instance = instance
+        this.sandbox = instance.getSandbox();
+        this.loc = instance.loc;
+        this.infoPopup = null;
+        this.filePopup = null;
+        this.mapPopup = null;
+        this.setState(getInitialState());
+        this.addStateListener(state => this.filePopup?.update(state));
+        Oskari.urls.set(WATCH_JOB, WATCH_URL);
+    }
+
+    reset (closeFlyout) {
+         // TODO: close popups? see onFlyoutClose
+        const state = getInitialState();
+        this.updateState(state); // TODO: set or update
+        if (closeFlyout) {
+            const flyout = this.instance.getFlyout();
+            // TODO: remove
+            flyout.mode = null;
+            flyout.close();
+        }
+    }
+
+    setSource (source) {
+        // TODO: confrim (jsx or popup) && clear
+        if (source === this.getState().source) {
+            return;
+        }
+        if (source === 'map') {
+            const inputSrs = this.sandbox.getMap().getSrsName();
+            this.updateState({ inputSrs });
+            this.selectFromMap();
+        }
+        this.updateState({ source });
+    }
+
+    addCoordinate (coordinate) {
+        const { coordinates } = this.getState();
+        this.updateState({ coordinates: [...coordinates, coordinate] });
+    }
+
+    updateCoordinate (index, coordinate) {
+        const coordinates = [...this.getState().coordinates];
+        // TODO: validate x,y,z getDimension (remove keys with empty value??)
+        coordinates[index] = coordinate;
+        // const updated = coordinates.map((c, i) => i === index ? coordinate : c);
+        this.updateState({ coordinates });
+    }
+
+    // paste 
+    pasteCoordinates (pasted) {
+        // TODO:
+        //  split("\n") for firefox and split(String.fromCharCode(13)) for Chrome
+        const coordinates = pasted.split(' ').map(s => s.split('\t')).map(([x, y, z]) => ({ x, y, z }));
+        this.updateState({ coordinates });
+    }
+
+    // parse float on blur
+    parseInputCoordinate (index, column) {
+        const { coordinates } = this.getState();
+        const { invalid, ...coord } = coordinates[index] || {};
+        const value = parseCoordinateValue(coord[column]);
+        // TODO: use column for invalid/error for styling ?
+        const updated = isNaN(value) ? {...coord, invalid: true} : { ...coord, [column]: value };
+        this.updateCoordinate(index, updated);
+    }
+    // TODO: refactor
+    setSrs (type, srs) {
+        const prop = `${type}Srs`;
+        this.updateState({ [prop]: srs });
+    }
+
+    setFiles (files) {
+        this.updateState({ files });
+    }
+    setFileSetting (type, key, value) {
+        const settings = this.getState()[type];
+        this.updateState({ [type]: { ...settings, [key]: value }});
+    }
+    // TODO: refactor
+    setImport (key, value) {
+        const current = this.getState().import;
+        this.updateState({ import: {...current, [key]: value} });
+    }
+    // TODO: refactor
+    setExport (key, value) {
+        const current = this.getState().export;
+        this.updateState({ export: {...current, [key]: value} });
+    }
+
+    clearTables () {
+        this.updateState({ coordinates: [], results: [] });
+    }
+
+    onAction (id) {
+        if (id === 'map') {
+            this.showMapPopup();
+        }
+        if (id === 'selectFromMap') {
+            this.selectFromMap();
+        }
+        if (id === 'showOnMap') {
+            this.showOnMap();
+        }
+        if (id === 'file') {
+            this.showFileSettings('import');
+        }
+        if (id === 'preview') {
+            this.transformToArray('F2R');
+        }
+        if (id === 'store') {
+            const coordinates = this.instance.getMapCoordinates();
+            this.instance.setMapSelectionMode();
+            this.updateState({ coordinates });
+        }
+        if (Object.values(MAP).includes(id)) {
+            this.instance.setMapSelectionMode(id);
+        }
+    }
+  
+    showOnMap () {
+        const { coordinates, inputSrs, source } = this.getState();
+        // TODO: notify noCoordinates, noSrs
+        if (this.mapPopup) {
+            return;
+        }
+        // TODO: convert to map projection (axis order) and add label (source !== map)
+        this.instance.setMapCoordinates(coordinates);
+        this.instance.toggleFlyout(false);
+        this.mapPopup = showMapPreviewPopup(() => this.closeMapPopup(true));
+    }
+
+    selectFromMap () {
+        const { coordinates } = this.getState();
+        this.instance.setMapSelectionMode(MAP.ADD);
+        this.instance.setMapCoordinates(coordinates);
+    }
+
+    showMapPopup () {
+        if (this.mapPopup) {
+            return;
+        }
+        this.selectFromMap();
+        this.instance.toggleFlyout(false);
+        this.mapPopup = showMapSelectPopup(this.getController(), () => this.closeMapPopup(true));
+    }
+
+    closeMapPopup (fromPopup) {
+        this.mapPopup?.close();
+        this.mapPopup = null;
+        if (fromPopup) {
+            this.instance.setMapSelectionMode();
+            this.instance.toggleFlyout(true);
+        }
+    }
+
+    showFileSettings (type) {
+        this.filePopup?.close(); // TODO: change, reset???
+        this.filePopup = showFilePopup(type, this.getState(), this.getController(),  () => this.closeFileSettings());
+    }
+
+    closeFileSettings () {
+        this.filePopup?.close();
+        this.filePopup = null;
+    }
+
+    showInfo (key) {
+        const { title, info = '', listItems = [], paragraphs = [info]} =  this.loc(`infoPopup.${key}`);
+        if (this.infoPopup) {
+            this.infoPopup.update(title, paragraphs, listItems);
+        } else {
+            this.infoPopup = showInfoPopup(title, paragraphs, listItems, () => this.closeInfoPopup());
+        }
+    }
+
+    showValidationError (errorKeys) {
+        this.infoPopup?.close();
+        const listItems = errorKeys.map(key => this.loc(`flyout.transform.validateErrors.${key}`));
+        const title = this.loc('flyout.transform.validateErrors.title');
+        const paragraphs = [this.loc('flyout.transform.validateErrors.message')]
+        this.infoPopup = showInfoPopup(title, paragraphs, listItems, () => this.closeInfoPopup());
+    }
+
+    closeInfoPopup () {
+        this.infoPopup?.close();
+        this.infoPopup = null;
+    }
+
+    onFlyoutClose () {
+        this.closeFileSettings();
+        this.closeInfoPopup();
+        this.closeMapPopup();
+    }
+
+    validate (stepOrType) {
+        const state = this.getState();
+        const isTransform = TRANSFORM.includes(stepOrType);
+        let errors = isTransform ? validateTransform(state, stepOrType) : [];
+        // const steps = Object.keys(CONTENT) // import from FlyoutWizard
+        if (!isTransform) {
+            if (stepOrType === 'inputSrs' && !state.inputSrs) {
+                errors.push('srs');
+            }
+            if (stepOrType === 'ouputSrs' && !state.outputSrs) {
+                errors.push('srs');
+            }
+            if (stepOrType === 'importFile') {
+                errors = [...errors, ...validateFileSettings(state, 'import')];
+            }
+            if (stepOrType === 'exportFile') {
+                errors = [...errors, ...validateFileSettings(state, 'export')];
+            }
+        }
+        if (errors.length) {
+            this.showValidationError(errors);
+        }
+        return errors.length > 0;
+    }
+
+    transformToFile (transformType) {
+        if (this.validate(transformType)) {
+            return;
+        }
+        this.updateState({ loading: true });
+        const state = this.getState();
+        const { params, body } = stateToPTIArray(state, transformType, true);
+        const { fileName } = state.export;
+        fetch(Oskari.urls.getRoute('CoordinateTransformation', params), {
+            method: 'POST',
+            body
+        }).then(response => {
+            if (!response.ok) {
+                throw new Error(response.statusText);
+            }
+            return response.json();
+        }).then(json => {
+            const { jobId } = json;
+            this.watchFileJob(jobId, fileName);
+        }).catch(() => {
+            Messaging.error(this.loc('transform.responseErrors.generic'));
+            this.updateState({ loading: false });
+        });
+    }
+
+    transformToArray (transformType) {
+        const state = this.getState();
+        // const type = transformType || 
+        if (this.validate(transformType)) {
+            return;
+        }
+        this.updateState({ loading: true });
+        
+        const { params, body } = stateToPTIArray(state, transformType, false);
+        fetch(Oskari.urls.getRoute('CoordinateTransformation', params), {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json'
+            },
+            body
+        }).then(response => {
+            return response.json();
+        }).then(json => {
+            const { jobId, inputCoordinates, error } = json;
+            if (jobId) {
+                this.watchJsonJob(jobId);
+            } else if (inputCoordinates && !error) {
+                // F2R returns coords immediately
+                const coordinates = inputCoordinates.map(([x, y, z]) => ({ x, y, z }));
+                this.updateState({ loading: false, coordinates });
+            } else {
+                this.showResponseError(json);
+            }
+        }).catch((e) => {
+            Messaging.error(this.loc('flyout.transform.responseErrors.generic'));
+            this.updateState({ loading: false });
+        });
+    }
+
+    watchJsonJob (jobId) {
+        fetch(Oskari.urls.getLocation(WATCH_JOB) + jobId, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json'
+            },
+            }).then(response => {
+            if (!response.ok) {
+                throw new Error(response.statusText);
+            }
+            return response.json();
+        }).then(json => {
+            const { jobId, resultCoordinates, hasMoreCoordinates } = json;
+            if (jobId) {
+                // set timeout??
+                this.watchJsonJob(jobId);
+                return;
+            } else if (resultCoordinates) {
+                // hasMoreCoordinates ??
+                // TODO: can undefined z cause problems??
+                const results = resultCoordinates.map(([x, y, z]) => ({ x, y, z }));
+                this.updateState({ loading: false, results });
+            } else {
+                this.showResponseError(json);
+            }
+        }).catch(() => {
+            Messaging.error(this.loc('flyout.transform.responseErrors.generic'));
+            this.updateState({ loading: false });
+        });
+    }
+
+    watchFileJob (jobId, fileName) {
+        fetch(Oskari.urls.getLocation(WATCH_JOB) + jobId, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json'
+            },
+            }).then(response => {
+            if (!response.ok) {
+                throw new Error(response.statusText);
+            }
+            // getFileNameFromResponse
+            return response.blob();
+        }).then(blob => {
+            if (!blob) {
+                // set timeout??
+                this.watchFileJob(jobId, fileName);
+                return;
+            }
+            loadFile(blob, fileName);
+            this.updateState({ loading: false });
+        }).catch(() => {
+            Messaging.error(this.loc('flyout.transform.responseErrors.generic'));
+            this.updateState({ loading: false });
+        });
+    }
+
+    showResponseError (response) {
+        const { error, info } = response || {};
+        const key = info?.errorKey || error?.errorKey || 'generic'
+        Oskari.log('CoordTransHandler').error(error);
+        Messaging.error(this.loc(`flyout.transform.responseErrors.${key}`));
+        this.updateState({ loading: false });
+    }
+}
+
+const wrapped = controllerMixin(UIHandler, [
+    'setSource',
+    'setSrs',
+    'updateCoordinate',
+    'pasteCoordinates',
+    'parseInputCoordinate',
+    'setFileSetting',
+    'setFiles',
+    'clearTables',
+    'showOnMap',
+    'transformToFile',
+    'transformToArray',
+    'showInfo',
+    'showFileSettings',
+    'onAction',
+    'reset',
+    'validate'
+]);
+
+export { wrapped as ViewHandler };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -1,0 +1,306 @@
+import { SRS, SRS_H, SYSTEM, MARKER, DEGREE_DECIMALS, DMS } from "./constants";
+
+export const getDimension = (srs, srsHeight) => {
+    const { system } = SRS.find(s => s.value === srs) || {};
+    // const { dimension } = SYSTEM.find(c => c.value === system) || {}
+    if (system === 'COORD_PROJ_3D' || system === 'COORD_GEOG_3D') {
+        return 3;
+    } else if (SRS_H.find(h => h.value === srsHeight)) {
+        return 3;
+    }
+    return 2;
+};
+
+export const isDegreeSystem = (srs) => {
+    const { system } = SRS.find(s => s.value === srs) || {};
+    if (system === 'COORD_GEOG_2D' || system === 'COORD_GEOG_3D') {
+        return true;
+    }
+    return false;
+};
+
+// TODO: is this needed => getDimension() === 3
+export const is3DSystem = (srs) =>  {
+    const { coord } = SRS.find(s => s.value === srs) || {};
+    if (coord === 'COORD_PROJ_3D' || coord === 'COORD_GEOG_3D') {
+        return true;
+    }
+    return false;
+};
+
+const getSrsUnit = srs => {
+    const { system } = SRS.find(s => s.value === srs) || {};
+    const { unit } = SYSTEM.find(c => c.value === system) || {};
+
+    return unit || 'metric';
+};
+
+export const validateTransform = (state, type) => {
+    if (type === 'F2R') {
+        return validateFileSettings(state, 'import');
+    }
+    if (type === 'A2A') {
+        return validateSelections(state);
+    }
+    if (type === 'F2A') {
+        return [...validateSelections(state), ...validateFileSettings(state, 'import')];
+    }
+    // import settings are validated on import
+    if (type === 'A2F' || type === 'F2F') {
+        return [...validateSelections(state), ...validateFileSettings(state, 'export')];
+    }
+    return ['message'];
+};
+const validateSelections = (state) => {
+    const errors = [];
+    // TODO: set import, set export, transform => split ??
+    if (!state.inputSrs || !state.outputSrs) {
+        errors.push('crs');
+    }
+    return errors;
+};
+
+export const validateFileSettings = (state, type) => {
+    const selects = state[type];
+    const errors = [];
+    
+    if (!selects.coordinateSeparator) {
+            errors.push('noCoordinateSeparator');
+    }
+    if (!selects.decimalSeparator) {
+        errors.push('noDecimalSeparator');
+    }
+
+    if (selects.decimalSeparator === ',' && selects.coordinateSeparator === 'comma') {
+        errors.push('doubleComma');
+    }
+    if (selects.coordinateSeparator === 'space' && (selects.unit === 'DD MM SS' || selects.unit === 'DD MM')) {
+        errors.push('doubleSpace');
+    }
+    if (type === 'import') {
+        if (!state.files.length) {
+            errors.push('noInputFile');
+        }
+        if (typeof selects.headerLineCount !== 'number' ||  selects.headerLineCount < 0) {
+            errors.push('headerCount');
+        }
+    }
+    if (type === 'export') {
+        if (!selects.fileName) {
+            errors.push('noFileName');
+        }
+        if (typeof selects.decimalCount !== 'number' ||  selects.decimalCount < 0) {
+            errors.push('decimalCount');
+        }
+    }
+    return errors;
+};
+
+export const getDecimalCount = (decimals, unit) => {
+    if (typeof decimals !== 'number') {
+        return 0;
+    }
+    switch (unit) {
+    case 'metric':
+        return decimals;
+    case 'DD MM SS':
+    case 'DDMMSS':
+        return decimals + 1;
+    case 'DD MM':
+    case 'DDMM':
+        return decimals + 3;
+    case 'degree':
+    case 'gradian':
+    case 'DD':
+        return decimals + 5;
+    case 'radian':
+        return decimals + 7;
+    default:
+        Oskari.log('CoordTransHelper').warn('Invalid unit - cannot get decimal count');
+        return 0;
+    }
+};
+
+export const getSystemsFromCompound = (epsg) => {
+    switch (epsg) {
+    case 'EPSG:3901': // YKJ + N60
+        return {
+            srs: 'EPSG:2393',
+            height: 'EPSG:5717'
+        };
+    case 'EPSG:3902': // ETRS-TM35FIN (N,E) + N60
+        return {
+            srs: 'EPSG:3067', // CoordTrans service doesn't support EPSG:5048, use EPSG:3047 (Identical except for area of use) or 3067 and axisFlip
+            height: 'EPSG:5717',
+            reversed: 'EPSG:5048'
+        };
+    case 'EPSG:3903': // ETRS-TM35FIN (N,E) + N2000
+        return {
+            srs: 'EPSG:3067', // CoordTrans service doesn't support EPSG:5048, use EPSG:3047 (Identical except for area of use) or 3067 and axisFlip
+            height: 'EPSG:3900',
+            reversed: 'EPSG:5048'
+        };
+    case 'EPSG:7409': // ETRS89 + EVRF2000 (EUREF-FIN-GRS80 + N60)
+        return {
+            srs: 'EPSG:4258',
+            height: 'EPSG:5717'
+        };
+    case 'EPSG:7423': // ETRS89 + EVRF2007 (EUREF-FIN-GRS80 + N2000)
+        return {
+            srs: 'EPSG:4258',
+            height: 'EPSG:3900'
+        };
+    }
+    return null;
+};
+
+// TODO: pass mapmodule or move to service/maphelper??
+export const isCoordInBounds = (srs, coord) => {
+    const { lonFirst, bounds } = SRS.find(s => s.value === srs);
+    const map = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
+    if (!bounds || !map) {
+        return false;
+    }
+    const x = lonFirst ? coord[0] : coord[1];
+    const y = lonFirst ? coord[1] : coord[0];   
+    return map.isPointInExtent(epsgValues.bounds, x, y);
+};
+// TODO: pass mapmodule or move to service/maphelper??
+export const moveMapToMarkers = (state) => {
+    // TODO: use converted map coordinates, this works only for native srs
+    const { coordinates, inputSrs } = state;
+    let { lonFirst } = SRS.find(s => s.value === inputSrs) || {};
+    const sandbox = Oskari.getSandbox();
+    const closestZoom = 6;
+    // TODO: isAxisFlip? input settings? is this needed with objects
+    //lonFirst = isAxisFlip ? !lonFirst : lonFirst;
+    if (!coordinates.length) {
+        // Nothing to do here
+    } else if (coordinates.length === 1) {
+        const { x, y } = coords[0];
+        sandbox.postRequestByName('MapMoveRequest', [x, y, closestZoom]);
+    } else {
+        const map = sandbox.findRegisteredModuleInstance('MainMapModule');
+        // TODO: array of objects
+        const extent = map.getExtentForPointsArray(coordinates);
+        // TODO: does this have zoom level optionn
+        map.zoomToExtent(extent);
+        if (map.getMapZoom() > closestZoom) {
+            map.setZoomLevel(closestZoom);
+        }
+    }
+};
+
+// TODO: refactor
+export const  getLabelForMarker = (lonlat, epsgValues, isAxisFlip) => {
+    let lonLabel;
+    let latLabel;
+    const val = epsgValues || this.mapEpsgValues;
+    const lonFirst = isAxisFlip ? !val.lonFirst : val.lonFirst;
+    if (val.coord === 'COORD_PROJ_3D') {
+        return 'X: ' + lonlat.lon + ', Y: ' + lonlat.lat + ', Z: ' + lonlat.height;
+    }
+    if (val.coord === 'COORD_GEOG_2D' || val.coord === 'COORD_GEOG_3D') {
+        lonLabel = this.loc('mapMarkers.show.lon');
+        latLabel = this.loc('mapMarkers.show.lat');
+    } else {
+        lonLabel = this.loc('mapMarkers.show.east');
+        latLabel = this.loc('mapMarkers.show.north');
+    }
+    // TODO do we need to localize decimal separator for label
+    // Oskari.getDecimalSeparator();
+    // lon = coords[].replace('.', Oskari.getDecimalSeparator());
+    if (lonFirst) {
+        return lonLabel + ': ' + lonlat.lon + ', ' + latLabel + ': ' + lonlat.lat;
+    } else {
+        return latLabel + ': ' + lonlat.lat + ', ' + lonLabel + ': ' + lonlat.lon;
+    }
+};
+
+export const coordinateToMarker = (coord, isNew) => {
+    const { colors, ...props } = MARKER;
+    const { x, y, label } = coord;
+    const msg = label || `E: ${x}, N: ${y}`;
+    const color = isNew ? colors.new : colors.old;
+    return  { ...props, x, y, msg, color };
+};
+
+// TODO: !
+const getTransformType = (source, target) => {
+    const from = source === 'file' ? 'F' : 'A';
+    const to = target;
+    return `${from}2${to}`;
+};
+
+export const stateToPTIArray = (state, transformType, toFile) => {
+    const { source, inputSrs, outputSrs, inputHeightSrs, outputHeightSrs} = state;
+    const dimension = transformType === 'F2R' ? 3 : getDimension(inputSrs, inputHeightSrs);
+    const params = {
+        sourceCrs: inputSrs,
+        sourceDimension: dimension,
+        sourceHeightCrs: inputHeightSrs,
+        targetCrs: outputSrs,
+        targetDimension: getDimension(outputSrs, outputHeightSrs),
+        targetHeightCrs: outputHeightSrs,
+        transformType
+    };
+
+    let body;
+    if (source === 'file') {
+        const formData = new FormData();
+        formData.append('importSettings', JSON.stringify(state.import));
+        formData.append('coordFile', state.files[0]);
+        if (toFile) {
+            formData.append('exportSettings', JSON.stringify(state.export));
+        }
+        body = formData;
+    } else {
+        if (toFile) {
+            const { decimalCount, unit, ...settings } = state.export;
+            const forced = isDegreeSystem(outputSrs) ? unit : 'metric';
+            const decimals = getDecimalCount(decimalCount, forced);
+            params.exportSettings = JSON.stringify({ ...settings, decimalCount: decimals, unit: forced });
+        }
+        const coordinates = state.coordinates
+            .filter( coord => !coord.invalid)
+            .map(({ x, y, z }) => dimension === 2 ? [x, y] : [x, y, z])
+            //.map(coord => coord.map(c => parseFloat(c)))
+            .filter(coord => coord.every(c => !isNaN(c)));
+        body = JSON.stringify(coordinates);
+    }
+    return {
+        params,
+        body
+    };
+};
+
+export const parseCoordinateValue = value => {
+    if (typeof value === 'number' || !value) {
+        return value;
+    }
+    // TODO: Oskari.util has only mehtod for point => use fake point[1]
+    // TODO: or DMS some value includes dms
+    if (Oskari.util.coordinateIsDegrees([value, '0\u00B0'])) {
+        return Oskari.util.coordinateDegreesToMetric([value, '0\u00B0'], DEGREE_DECIMALS)[0];
+    } 
+    // TODO: refactor
+    // DMS with spaces only (not ° ' ")
+    if (value.includes(' ') && value.split(' ').filter(v => !isNaN(v).length > 1)) {
+        // double spaces??
+        const suffixed = value.split(' ').map((v, i) => v + DMS[i]).join(' ');
+        return Oskari.util.coordinateDegreesToMetric([suffixed, '0\u00B0'], DEGREE_DECIMALS)[0];
+        // TODO: or split filter empty map parseFloat / 60 ** i
+    }
+    return parseFloat(value.replace(',', '.'));
+};
+
+export const loadFile = (file, name) => {
+    const elem = document.createElement('a');
+    const href = window.URL.createObjectURL(file);
+    elem.href = href;
+    elem.download = name || 'results.txt';
+    document.body.appendChild(elem);
+    elem.click();
+    document.body.removeChild(elem);
+    window.URL.revokeObjectURL(href);
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/index.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/index.js
@@ -1,0 +1,4 @@
+import './instance';
+
+// register create function for bundleid
+Oskari.bundle('coordinatetransformation', () => Oskari.clazz.create('Oskari.coordinatetransformation.instance'));

--- a/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/instance.js
@@ -1,151 +1,77 @@
+import './Flyout.js';
+import { MAP, ID_PREFIX } from './constants';
+import { coordinateToMarker } from './helper';
+
 Oskari.clazz.define('Oskari.coordinatetransformation.instance',
     function () {
         this.defaultConf.name = 'coordinatetransformation';
         this.defaultConf.flyoutClazz = 'Oskari.coordinatetransformation.Flyout';
-        this.transformationService = null;
-        this.dataHandler = null;
-        this.views = null;
-        this.helper = null;
         this.loc = Oskari.getMsg.bind(null, 'coordinatetransformation');
-        this.isMapSelection = false;
-        this.isRemoveMarkers = false;
+        this.mapSelection = null;
+        this.tempCoords = []; // {id, x, y, ?label?}
         this.sandbox = Oskari.getSandbox();
-        // TODO should dimensions be handled by dataHandler
-        this.dimensions = {
-            input: 2,
-            output: 2
-        };
     }, {
         __name: 'coordinatetransformation',
         getName: function () {
             return this.__name;
         },
-        getViews: function () {
-            return this.views;
+        getFlyout: function () {
+            return this.plugins['Oskari.userinterface.Flyout'];
         },
-        getService: function () {
-            return this.transformationService;
+        toggleFlyout: function (visible) {
+            const mode = visible ? 'attach' : 'hide';
+            this.sandbox.postRequestByName('userinterface.UpdateExtensionRequest', [this, mode]);
         },
-        setDimension: function (type, srs, elevation) {
-            this.dimensions[type] = this.helper.getDimension(srs, elevation);
-        },
-        getDimension: function (type) {
-            return this.dimensions[type];
-        },
-        getDimensions: function () {
-            return this.dimensions;
-        },
-        /**
-     * @method afterStart
-     */
-        afterStart: function () {
-            this.helper = Oskari.clazz.create('Oskari.coordinatetransformation.helper');
-            this.transformationService = Oskari.clazz.create('Oskari.coordinatetransformation.TransformationService', this);
-            this.dataHandler = Oskari.clazz.create('Oskari.coordinatetransformation.CoordinateDataHandler', this.helper);
-            this.instantiateViews();
-            this.createUi();
-            this.bindListeners();
-        },
-        bindListeners: function () {
-            const me = this;
-            const dimensions = this.getDimensions();
-            this.dataHandler.on('InputCoordAdded', function (coords) {
-                me.views.transformation.inputTable.render(coords, dimensions.input);
-            });
-            this.dataHandler.on('InputCoordsChanged', function (coords) {
-                me.views.transformation.inputTable.render(coords, dimensions.input);
-            });
-            this.dataHandler.on('ResultCoordsChanged', function (coords) {
-                me.views.transformation.outputTable.render(coords, dimensions.output);
-            });
-        },
-        getPlugins: function () {
-            return this.plugins;
-        },
-        getDataHandler: function () {
-            return this.dataHandler;
-        },
-        getHelper: function () {
-            return this.helper;
-        },
-        instantiateViews: function () {
-            this.views = {
-                transformation: Oskari.clazz.create('Oskari.coordinatetransformation.view.transformation', this, this.helper, this.dataHandler),
-                MapSelection: Oskari.clazz.create('Oskari.coordinatetransformation.view.CoordinateMapSelection', this),
-                mapmarkers: Oskari.clazz.create('Oskari.coordinatetransformation.view.mapmarkers', this)
-            };
-        },
-        toggleViews: function (view) {
-            const views = this.getViews();
-            if (views[view]) {
-                views[view].setVisible(true);
+        setMapSelectionMode: function (mode) {
+            const stopped = !mode;
+            this.sandbox.postRequestByName('MapModulePlugin.GetFeatureInfoActivationRequest', [stopped]);
+            if (stopped) {
+                this.setMapCoordinates([]);
             }
-            Object.keys(views).forEach(function (key) {
-                if (view !== key) {
-                    views[key].setVisible(false);
-                }
+            this.mapSelection = mode;
+        },
+        getMapCoordinates: function () {
+            // remove id
+            return this.tempCoords.map(({x, y}) => ({ x, y }));
+        },
+        setMapCoordinates: function (coords) {
+            // Remove previous
+            this.tempCoords.forEach(({id}) => this.sandbox.postRequestByName('MapModulePlugin.RemoveMarkersRequest', [id]));
+            this.tempCoords = [];
+            
+            this.tempCoords = coords.map(coord => ({ ...coord, id: ID_PREFIX + Oskari.getSeq(this.getName()).nextVal()}));
+            this.tempCoords.forEach(coord => {
+                const marker = coordinateToMarker(coord);
+                this.sandbox.postRequestByName('MapModulePlugin.AddMarkerRequest', [marker, coord.id]);
             });
         },
-        clearPopupsAndMarkers: function () {
-            this.views.MapSelection.setVisible(false);
-            this.views.mapmarkers.setVisible(false);
-            this.views.transformation.closePopups();
-            this.helper.removeMarkers();
-            this.addMapCoordsToInput(false);
-            this.setMapSelectionMode(false);
-        },
-        createUi: function () {
-            this.plugins['Oskari.userinterface.Flyout'].createUi();
-        },
-        setMapSelectionMode: function (isSelect) {
-            this.isMapSelection = !!isSelect;
-            if (isSelect === true) {
-                this.sandbox.postRequestByName('MapModulePlugin.GetFeatureInfoActivationRequest', [false]);
-            } else {
-                this.sandbox.postRequestByName('MapModulePlugin.GetFeatureInfoActivationRequest', [true]);
-            }
-        },
-        setRemoveMarkers: function (isRemove) {
-            this.isRemoveMarkers = isRemove;
-        },
-        addMapCoordsToInput: function (addBln) { // event??
-            this.getDataHandler().addMapCoordsToInput(addBln);
-        },
-        /**
-     * Creates the coordinatetransformation service and registers it to the sandbox.
-     * @method createService
-     * @param  {Oskari.Sandbox} sandbox
-     * @return {Oskari.coordinatetransformation.TransformationService}
-     *
-    createService: function(sandbox) {
-        var transformationService = Oskari.clazz.create( 'Oskari.coordinatetransformation.TransformationService', this );
-        sandbox.registerService(transformationService);
-        return transformationService;
-    }, */
         eventHandlers: {
             'MapClickedEvent': function (event) {
-                if (!this.isMapSelection || this.isRemoveMarkers) {
+                if (this.mapSelection !== MAP.ADD) {
                     return;
                 }
-                const lonlat = event.getLonLat();
-                const roundedLonLat = {
-                    lon: parseInt(lonlat.lon),
-                    lat: parseInt(lonlat.lat)
+                const { lon, lat } = event.getLonLat();
+                // This assumes lon first (3067)
+                const coord = {
+                    x: parseInt(lon),
+                    y: parseInt(lat),
+                    id: ID_PREFIX + Oskari.getSeq(this.getName()).nextVal()
                 };
-                // add coords to map coords
-                const markerId = this.dataHandler.addMapCoord(roundedLonLat);
-                const label = this.helper.getLabelForMarker(roundedLonLat);
-                this.helper.addMarkerForCoords(markerId, roundedLonLat, label);
+                this.tempCoords.push(coord);
+                const marker = coordinateToMarker(coord, true);
+                this.sandbox.postRequestByName('MapModulePlugin.AddMarkerRequest', [marker, coord.id]);
             },
             'MarkerClickEvent': function (event) {
-                if (!this.isMapSelection) {
+                if (this.mapSelection !== MAP.REMOVE) {
                     return;
                 }
-                const markerId = event.getID();
-                if (this.isRemoveMarkers === true) {
-                    this.dataHandler.removeMapCoord(markerId);
-                    this.sandbox.postRequestByName('MapModulePlugin.RemoveMarkersRequest', [markerId]);
+                const id = event.getID();
+                if (!id.startsWith(ID_PREFIX)) {
+                    return;
                 }
+                this.tempCoords = this.tempCoords.filter(coord => coord.id !== id);
+                // TODO: add some check that we remove only own markers => id starts with prefix etc
+                this.sandbox.postRequestByName('MapModulePlugin.RemoveMarkersRequest', [id]);
             },
             'userinterface.ExtensionUpdatedEvent': function (event) {
                 if (event.getExtension().getName() !== this.getName()) {
@@ -153,17 +79,17 @@ Oskari.clazz.define('Oskari.coordinatetransformation.instance',
                 }
                 const state = event.getViewState();
                 if (state === 'attach') {
-                    this.plugins['Oskari.userinterface.Flyout'].setContainerMaxHeight(Oskari.getSandbox().getMap().getHeight());
+                    this.getFlyout().setContainerMaxHeight(Oskari.getSandbox().getMap().getHeight());
                     this.sandbox.postRequestByName('DisableMapKeyboardMovementRequest');
                 } else if (state === 'close') {
-                    this.clearPopupsAndMarkers();
+                    this.getFlyout().teardown();
                     this.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');
                 } else if (state === 'hide') {
                     this.sandbox.postRequestByName('EnableMapKeyboardMovementRequest');
                 }
             },
             'MapSizeChangedEvent': function (event) {
-                this.plugins['Oskari.userinterface.Flyout'].setContainerMaxHeight(event.getHeight());
+                this.getFlyout().setContainerMaxHeight(event.getHeight());
             }
         }
     }, {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -14,13 +14,23 @@ Oskari.registerLocalization(
                 "epsg": "EPSG-koodilla",
                 "systems": "Datumilla ja koordinaatistolla"
             },
+            "steps": {
+                "inputSrs": "Lähtökoordinaattijärjestelmä",
+                "outputSrs": "Tuloskoordinaattijärjestelmä",
+                "importFile": "Lähtöaineisto",
+                "exportFile": "Tulosaineisto",
+                "mapSelect": "Valitse sijainnit",
+                "inputTable": "Lähtökoordinaatit",
+                "mapInputTable": "Kartan koordinaatit",
+                "resultTable": "Tuloskoordinaatit"
+            },
             "coordinateSystem": {
                 "title": "Koordinaattijärjestelmän tiedot",
                 "input": {
-                    "title": "Lähtökoordinaattijärjestelmän tiedot"
+                    "title": "Anna lähtökoordinaattijärjestelmän tiedot"
                 },
                 "output": {
-                    "title": "Tuloskoordinaattijärjestelmän tiedot"
+                    "title": "Anna tuloskoordinaattijärjestelmän tiedot"
                 },
                 "noFilter": "Mikä tahansa",
                 "epsgSearch": {
@@ -57,15 +67,31 @@ Oskari.registerLocalization(
             "coordinateTable": {
                 "input": "Muunnettavat koordinaatit",
                 "output": "Tuloskoordinaatit",
-                "north":"Pohjois-koordinaatti [m]",
-                "east":"Itä-koordinaatti [m]",
-                "lat":"Leveysaste",
-                "lon":"Pituusaste",
-                "elevation": "Korkeus [m]",
-                "geoX":"Geosentrinen X [m]",
-                "geoY":"Geosentrinen Y [m]",
-                "geoZ":"Geosentrinen Z [m]",
-                "ellipseElevation":"Ellipsoidinen korkeus [m]",
+                "metric": {
+                    "x":"Pohjois-koordinaatti [m]",
+                    "y":"Itä-koordinaatti [m]",
+                    "z": "Korkeus [m]"
+                },
+                "degree": {
+                    "x":"Leveysaste",
+                    "y":"Pituusaste",
+                    "z": "Korkeus [m]",
+                },
+                "degree3D": {
+                    "x":"Leveysaste",
+                    "y":"Pituusaste",
+                    "z": "Ellipsoidinen korkeus [m]",
+                },
+                "geocentric": {
+                    "x":"Geosentrinen X [m]",
+                    "y":"Geosentrinen Y [m]",
+                    "z":"Geosentrinen Z [m]"
+                },
+                "height": {
+                    "elevation": "Korkeus [m]",
+                    "ellipse":"Ellipsoidinen korkeus [m]",
+                    "geocentric": "Geosentrinen Z [m]"
+                },
                 "rows": "Riviä",
                 "clearTables": "Tyhjennä taulukot",
                 "confirmClear": "Haluatko tyhjentää taulukot?"
@@ -82,6 +108,7 @@ Oskari.registerLocalization(
                     "title": "Virhe!",
                     "message": "Valinnoissa on puutteita tai virheitä. Ota huomioon seuraavat vaatimukset ja yritä uudelleen.",
                     "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
+                    "srs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna.",
                     "noInputData": "Ei muunnettavia koordinaatteja.",
                     "noInputFile": "Lähtöaineiston sisältävä tiedosto pitää olla valittuna.",
                     "noFileName": "Muodostettavalle tiedostolle pitää antaa tiedostonimi.",
@@ -102,8 +129,8 @@ Oskari.registerLocalization(
                     "generic": "Koordinaattimuunnos epäonnistui.",
                     //error codes
                     "invalid_coord": "Koordinaatti virheellinen. Tarkasta, että muunnettavat koordinaatit ovat oikeassa muodossa sekä geodeettinen koordinaatti- ja korkeusjärjestelmä ovat oikein.",
-                    //"invalid_number": "Koordinaatti virheellinen.",
-                    //"invalid_coord_in_array": "Koordinaatti virheellinen.",
+                    "invalid_number": "Koordinaatti virheellinen.",
+                    "invalid_coord_in_array": "Koordinaatti virheellinen.",
                     "no_coordinates": "Tiedostosta ei löytynyt koordinaatteja. Tarkasta tiedosto sekä asetettu otsakerivien määrä.",
                     "invalid_file_settings": "Tiedoston asetukset virheelliset.",
                     "no_file": "Lähetetystä pyynnöstä ei löytynyt tiedostoa.",
@@ -119,14 +146,15 @@ Oskari.registerLocalization(
         },
         "dataSource": {
             "title": "Koordinaattitietojen lähde",
+            "change": "Vaihda lähde",
             "confirmChange": "Muunnettavat koordinaatit tyhjennetään. Haluatko jatkaa?",
             "file": {
-                "label": "Tiedostosta",
+                "label": "Tiedosto",
                 "info":  "Valitse lähtöaineiston sisältävä tiedosto ja sen asetukset.",
                 "action": "muokkaa valintoja"
             },
-            "keyboard": {
-                "label": "Näppäimistöltä",
+            "table": {
+                "label": "Taulukko",
                 "info": "Syötä lähtötiedot Muunnettavat koordinaatit -taulukkoon."
             },
             "map": {
@@ -156,8 +184,9 @@ Oskari.registerLocalization(
             }
         },
         "actions": {
-            "convert": "Muunna",
-            "export": "Muunna tiedostoon",
+            "convert": "Tee muunnos",
+            "export": "Tee muunnos tiedostoon",
+            "minimizeSrs": "Näytä kaikki koordinaattjijärjestelmän valinnat",
             "select": "Valitse",
             "cancel": "Peruuta",
             "done": "Valmis",
@@ -168,27 +197,25 @@ Oskari.registerLocalization(
             "options": {
                 "decimalSeparator": "Desimaalierotin",
                 "coordinateSeparator": "Sarake-erotin",
-                "headerCount": "Otsakerivien määrä",
-                "decimalPrecision": "Desimaalien tarkkuus",
-                "reverseCoordinates": "Koordinaatit käänteisesti",
+                "headerLineCount": "Otsakerivien määrä",
+                "decimalCount": "Desimaalien tarkkuus",
+                "axisFlip": "Koordinaatit käänteisesti",
+                "prefixId": "Koordinaatit sisältävät tunnisteet",
                 "useId": {
-                    "input": "Koordinaatit sisältävät tunnisteet",
                     "generate": "Luo tunnisteet",
                     "add": "Lisää tunnisteet",
                     "fromFile": "Lisää tunnisteet lähtötiedostosta"
                 },
                 "writeHeader": "Kirjoita otsakerivi tiedostoon",
-                "useCardinals": "Käytä kardinaaleja (N,E,W,S)",
-                "lineEnds": "Rivin loput tulokseen",
+                "writeCardinals": "Käytä kardinaaleja (N,E,W,S)",
+                "writeLineEndings": "Rivin loput tulokseen",
+                "lineSeparator": "Rivierotin",
+                "unit": "Kulman muoto/yksikkö",
                 "choose": "Valitse",
                 "degreeFormat":{
-                    "label": "Kulman muoto/yksikkö",
                     "degree": "Aste",
                     "gradian": "Gooni (graadi)",
                     "radian": "Radiaani"
-                },
-                "lineSeparator": {
-                    "label": "Rivierotin"
                 },
                 "delimeters":{
                     "point": "Piste",
@@ -208,7 +235,7 @@ Oskari.registerLocalization(
         },
         "infoPopup": {
             "description": "Kuvaus",
-            "keyboard": {
+            "table": {
                 "title": "Koordinaattitietojen lähde - taulukko",
                 "paragraphs": [
                     "Syötä lähtötiedot Muunnettavat koordinaatit -taulukkoon."
@@ -349,7 +376,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "reverseCoordinates":{
+            "axisFlip":{
                 "title":"Koordinaatit käänteisesti",
                 "info": "X- ja Y-koordinaattiakselien järjestys poikkeaa määritetystä järjestyksestä",
                 "paragraphs": [
@@ -367,7 +394,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "lineEnds":{
+            "writeLineEndings":{
                 "title":"Rivin loput tulokseen",
                 "info": "Lähtötiedoston rivin loput lisätään tulostiedostoon",
                 "paragraphs": [
@@ -376,7 +403,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "useCardinals":{
+            "writeCardinals":{
                 "title":"Kardinaalien käyttö",
                 "info": "Koordinaattiarvojen perään lisätään ilmansuunnat (N, E, W tai S)",
                 "paragraphs": [

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FilePopup.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FilePopup.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+import { showPopup } from 'oskari-ui/components/window';
+import { LocaleProvider } from 'oskari-ui/util';
+import { Message, Button } from 'oskari-ui';
+import { SecondaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
+import { ImportFile, ExportFile } from '../components/FileSettings';
+
+import { BUNDLE } from '../constants';
+
+const POPUP_OPTIONS = {
+    id: BUNDLE + '-file'
+};
+
+const Content = styled.div`
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+`;
+
+const getContent = (type, state, controller, onClose) => {
+    const Node = type ==='import' ? ImportFile : ExportFile;
+    const onPrimary = () => {
+        if (controller.validate(`${type}File`)) {
+            return;
+        }
+        if (type ==='import') {
+            controller.transformToArray('F2R');
+        } else {
+            const transformType = state.source === 'file' ? 'F2F' : 'A2F';
+            controller.transformToFile(transformType);
+        }
+        onClose();
+    };
+    return (
+        <LocaleProvider value={{ bundleKey: BUNDLE }}>
+            <Content>
+                <Node {...state} controller={controller}/>
+                <ButtonContainer>
+                    <SecondaryButton type='cancel' onClick={onClose} />
+                    <Button type='primary' onClick={onPrimary}>
+                        <Message messageKey={type ==='import' ? 'actions.done' : 'actions.export'}/>
+                    </Button>
+                </ButtonContainer>
+            </Content>
+        </LocaleProvider>
+    );
+};
+
+export const showFilePopup = (type, state, controller, onClose) => {
+    const title = <Message messageKey={`fileSettings.${type}.title`} bundleKey={BUNDLE} />
+    const controls = showPopup(
+        title,
+        getContent(type, state, controller, onClose),
+        onClose,
+        POPUP_OPTIONS
+    );
+    return {
+        ...controls,
+        update: state => controls.update(title, getContent(type, state, controller, onClose))
+    };
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Button} from 'oskari-ui';
+import { ButtonContainer } from 'oskari-ui/components/buttons';
+import { SourceSelect } from '../components/SourceSelect.jsx';
+import { CoordinateTable } from '../components/CoordinateTable.jsx';
+import { SrsSelect } from '../components/SrsSelect';
+import { ClearTableButton } from '../components/ClearTableButton';
+
+const Content = styled.div`
+    display: flex;
+    flex-flow: column;
+    gap: 2em;
+`;
+// TODO: mobile column
+const Splitter = styled.div`
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 2em;
+`;
+const MinimizeButton = styled(Button)`
+    justify-content: flex-start;
+    padding: 0;
+`;
+const StyledButtonContainer = styled(ButtonContainer)`
+    justify-content: space-between;
+`;
+
+export const FlyoutContent = ({
+    controller,
+    source,
+    coordinates,
+    results,
+    inputSrs,
+    inputHeightSrs,
+    outputHeightSrs,
+    outputSrs
+}) => {
+    const [ minimalSrs, setMinimalSrs ] = useState(true);
+    const transformType = source === 'file' ? 'F2A' : 'A2A';
+    return (
+        <Content>
+            <div className='t_srs'>
+                <Splitter>
+                    <SrsSelect type='input' minimal={minimalSrs} srs={inputSrs} heightSrs={inputHeightSrs} controller={controller}/>
+                    <SrsSelect type='output' minimal={minimalSrs} srs={outputSrs} heightSrs={outputHeightSrs} controller={controller}/>
+                </Splitter>
+                <MinimizeButton type='link' onClick={() => setMinimalSrs(!minimalSrs)}>
+                    <Message messageKey='actions.minimizeSrs'/>
+                </MinimizeButton>
+            </div>
+            <SourceSelect value={source} controller={controller} />
+            <Splitter>
+                <CoordinateTable type='input' editable={source === 'table'} srs={inputSrs} heightSrs={inputHeightSrs} coordinates={coordinates} controller={controller} />
+                <CoordinateTable type='output' srs={outputSrs} heightSrs={outputHeightSrs} coordinates={results} controller={controller} />
+            </Splitter>
+            
+            <StyledButtonContainer>
+                <div className='t_actions'>
+                    <ClearTableButton controller={controller} />
+                    <Button onClick={() => controller.onAction('showOnMap')}>
+                        <Message messageKey='mapMarkers.show.title'/>
+                    </Button>
+                </div>
+                <div className='t_transform'>
+                    <Button type='primary' onClick={() => controller.transformToArray(transformType)}>
+                        <Message messageKey='actions.convert'/>
+                    </Button>
+                    <Button type='primary' onClick={() => controller.showFileSettings('export')}>
+                        <Message messageKey='actions.export'/>
+                    </Button>
+                </div>
+            </StyledButtonContainer>
+        </Content>
+    );
+};
+
+FlyoutContent.propTypes = {
+    loading: PropTypes.bool,
+    srs: PropTypes.object.isRequired,
+    source: PropTypes.string,
+    transformType: PropTypes.string,
+    inputSrs: PropTypes.string,
+    outputSrs: PropTypes.string,
+    file: PropTypes.any,
+    coordinates: PropTypes.array.isRequired,
+    results: PropTypes.array.isRequired,
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutWizard.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutWizard.jsx
@@ -1,0 +1,182 @@
+import React, { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Button, Steps, Confirm } from 'oskari-ui';
+import { ComponentLabel } from '../components/ComponentLabel';
+import { InfoIcon } from 'oskari-ui/components/icons';
+import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
+import { MapSelect } from '../components/MapSelect';
+import { InputCoordinates, OutputCoordinates } from '../components/CoordinateTable.jsx';
+import { InputSrs, OutputSrs } from '../components/SrsSelect';
+import { ImportFile, ExportFile } from '../components/FileSettings';
+import { ClearTableButton } from '../components/ClearTableButton';
+import { SOURCE } from '../constants';
+
+const ContentWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2em;
+`;
+const SourceButtons = styled.div`
+    display: flex;
+    gap: 2em;
+`;
+// TODO: mobile column
+const Spitter = styled.div`
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 1em;
+`;
+const StyledButtonContainer = styled(ButtonContainer)`
+    justify-content: space-between;
+`;
+
+const ResultTable = (props) => (
+    <Spitter>
+        <InputCoordinates {...props} />
+        <OutputCoordinates {...props} />
+    </Spitter>
+);
+
+const CONTENT = {
+    mapSelect: { component: MapSelect, onNext: 'store' },
+    inputSrs: { component: InputSrs },
+    outputSrs: { component: OutputSrs },
+    importFile: { component: ImportFile, onNext: 'preview' },
+    exportFile: { component: ExportFile },
+    inputTable: { component: InputCoordinates  },
+    mapInputTable: { component: InputCoordinates, onPrevious: 'selectFromMap' },
+    resultTable: { component: ResultTable }
+};
+
+const STEPS = {
+    map: ['mapSelect', 'mapInputTable', 'outputSrs'],
+    file: ['inputSrs', 'importFile', 'inputTable', 'outputSrs'],
+    table: ['inputSrs', 'inputTable', 'outputSrs']
+};
+
+export const FlyoutWizard = ({
+    state,
+    controller
+}) => {
+    const [stepIndex, setStepIndex] = useState(-1);
+    const [showExport, setShowExport] = useState(false);
+    const lastStep = showExport ? 'exportFile' : 'resultTable';
+    const steps = STEPS[state.source] ? [ ...STEPS[state.source], lastStep ] : [];
+    const step = steps[stepIndex];
+    const { component: Content, type, onNext, onPrevious } = CONTENT[step] || {};
+
+    if (!Content) {
+        const onSourceClick = id => {
+            controller.setSource(id);
+            setStepIndex(0);
+        };
+        const onInfoClick = (event, id) => {
+            event.preventDefault();
+            event.stopPropagation();
+            controller.showInfo(id);
+        };
+        return (
+            <ContentWrapper>
+                <ComponentLabel label='dataSource.title'/>
+                <SourceButtons>
+                    { SOURCE.map( id => (
+                        <Button key={id} onClick={() => onSourceClick(id)}>
+                            <Message messageKey={`dataSource.${id}.label`} />
+                            <span onClick={(evt) => onInfoClick(evt, id)}>
+                                <InfoIcon title={<Message messageKey={`dataSource.${id}.info`} />} />
+                            </span>
+                        </Button>
+                    ))}
+                </SourceButtons>
+            </ContentWrapper>
+        );
+    }
+
+    const nextStep = () => {
+        if (controller.validate(step)) {
+            return;
+        }
+        if (onNext) {
+            controller.onAction(onNext);
+        }
+        setStepIndex(stepIndex + 1);
+    };
+
+    const previousStep = () => {
+        if (onPrevious) {
+            controller.onAction(onPrevious);
+        }
+        setStepIndex(stepIndex - 1);
+    };
+    const exportToFile = () => {
+        setShowExport(true);
+        nextStep();
+    };
+    const trasnformToTable = () => {
+        const transformType = state.source === 'file' ? 'F2A' : 'A2A';
+        controller.transformToArray(transformType);
+        nextStep();
+    };
+    const onSourceChangeConfirm = () => {
+        controller.reset();
+        setStepIndex(-1);
+    };
+    const lastIndex = stepIndex >= steps.length - 1;
+    const showMapMarkers = step === 'resultTable' || step === 'inputTable';
+    // TODO: result tab to own jsx if wizard is used
+    // TODO: getter or component for secondary and primary button (actions, steps)
+    // TODO: Steps items is required prop, but it doesn't work (antd examples uses items also) => map items to Step in oskari-ui??
+    if (true) {
+        return (
+            <ContentWrapper>
+                <Steps size='small' current={stepIndex} >
+                    {steps.map(id =>
+                        <Steps.Step key={id} title={<Message messageKey={`flyout.steps.${id}`} />} />
+                    )}
+                </Steps>
+                <Content { ...state } type={type} controller={controller} />
+                <StyledButtonContainer>
+                    <div className='t_actions'>
+                    <Confirm
+                        title={<Message messageKey='dataSource.confirmChange'/>}
+                        onConfirm={onSourceChangeConfirm}>
+                        <Button>
+                            <Message messageKey='dataSource.change'/>
+                        </Button>
+                    </Confirm>
+                    { showMapMarkers &&
+                        <Button onClick={() => controller.onAction('showOnMap')}>
+                            <Message messageKey='mapMarkers.show.title'/>
+                        </Button>
+                    }
+                    </div>
+                    <div className='t_steps'>
+                        { stepIndex > 0 && <SecondaryButton type='previous' onClick={previousStep}/> }
+                        { stepIndex < steps.length - 2  && <PrimaryButton type='next' onClick={nextStep}/> }
+                        { stepIndex === steps.length - 2 &&
+                            <Fragment>
+                                <Button type='primary' onClick={trasnformToTable}>
+                                    <Message messageKey='actions.convert'/>
+                                </Button>
+                                <Button type='primary' onClick={exportToFile}>
+                                    <Message messageKey='actions.export'/>
+                                </Button>
+                            </Fragment>
+                        }
+                        { stepIndex >= steps.length - 1 && <PrimaryButton type='close' onClick={() => controller.reset(true)}/> }
+                        { step === 'exportFile' && 
+                            <Button type='primary' onClick={() => controller.transformToFile(state.source === 'file' ? 'F2F' : 'A2F')}>
+                                <Message messageKey='actions.export'/>
+                            </Button>
+                        }
+                    </div>
+                </StyledButtonContainer>
+            </ContentWrapper>
+        );
+    }
+};
+FlyoutWizard.propTypes = {
+    state: PropTypes.object.isRequired,
+    controller: PropTypes.object.isRequired
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/InfoPopup.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/InfoPopup.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import { showPopup } from 'oskari-ui/components/window';
+import { BUNDLE } from '../constants';
+
+const POPUP_OPTIONS = {
+    id: BUNDLE + '-info'
+};
+
+const Content = styled.div`
+    padding: 20px;
+`;
+const Paragraph = styled.p`
+    padding-bottom: 12px;
+`;
+
+const List = ({ items }) => {
+    if (!items.length) {
+        return null;
+    }
+    return (
+        <ul>
+            {items.map((item, i) => <li key={`li_${i}`}>{item}</li>)}
+        </ul>
+    )
+};
+const getContent = (paragraphs, listItems) => (
+    <Content>
+        {paragraphs.map((p,i) => <Paragraph key={`p_${i}`}>{p}</Paragraph>)}
+        <List items={listItems} />
+    </Content>
+);
+
+export const showInfoPopup = (title, paragraphs, listItems, onClose) => {
+    const controls = showPopup(
+        title,
+        getContent(paragraphs, listItems),
+        onClose,
+        POPUP_OPTIONS
+    );
+    return {
+        ...controls,
+        update: (title, paragraphs, listItems) => controls.update(title, getContent(paragraphs, listItems))
+    };
+};

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/MapPopup.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/MapPopup.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { showPopup, PLACEMENTS } from 'oskari-ui/components/window';
+import { SecondaryButton, ButtonContainer, PrimaryButton } from 'oskari-ui/components/buttons';
+import { Message, Label, Radio, Button } from 'oskari-ui';
+import { MapSelect } from '../components/MapSelect';
+import { BUNDLE, MAP } from '../constants';
+
+const POPUP_OPTIONS = {
+    id: BUNDLE + '-map',
+    placement: PLACEMENTS.TL
+};
+
+const ContentWrapper = styled.div`
+    padding: 20px;
+`;
+
+const Content = ({ controller, onClose }) => {
+    const onPrimary = () => {
+        controller.onAction('store');
+        onClose();
+    };
+
+    return (
+        <ContentWrapper>
+            <MapSelect controller={controller} />
+            <ButtonContainer>
+                <SecondaryButton type='cancel' onClick={onClose} />
+                <Button type='primary' onClick={onPrimary}>
+                    <Message messageKey='actions.done' bundleKey={BUNDLE}/>
+                </Button>
+            </ButtonContainer>
+        </ContentWrapper>
+    );
+};
+
+export const showMapSelectPopup = (controller, onClose) => {
+    return showPopup(
+        <Message messageKey='mapMarkers.select.title' bundleKey={BUNDLE} />,
+        <Content controller={controller} onClose={onClose} />,
+        onClose,
+        POPUP_OPTIONS
+    );
+};
+
+export const showMapPreviewPopup = (onClose) => {
+    return showPopup(
+        <Message messageKey='mapMarkers.show.title' bundleKey={BUNDLE} />,
+        (<ContentWrapper>
+            <Message messageKey='mapMarkers.show.info' bundleKey={BUNDLE} />
+            <ButtonContainer>
+                <PrimaryButton type='close' onClick={onClose} />
+            </ButtonContainer>
+        </ContentWrapper>),
+        onClose,
+        POPUP_OPTIONS
+    );
+};


### PR DESCRIPTION
First round for using React.  Add react handler, components and views. `sv`and `en` doesn't have localization updates.  Flyout has buttons to use wizard or normal flyout content.

Commit: https://github.com/nls-oskari/pti-frontend/commit/fa419c978b8f12c7fd56220fcd4778290b102843 contains changes for using React (instance, Flyout, fi.js, main,js, index.js)