### PR TITLE
KOMU: Fix file import prefix column setting and improve preview

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/FilePreview.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/FilePreview.jsx
@@ -5,6 +5,24 @@ import { ErrorBoundary } from 'oskari-ui/util';
 
 const MAX_COLUMNS = 4;
 
+const PreviewCellStyle = styled.td`
+text-align: center;
+&.invalid {
+    box-shadow: inset 0 0 2px 2px rgba(255,50,0,0.4);
+    padding: 8px;
+}
+`;
+
+const HasMoreCell = styled.td`
+text-align: right !important;
+`;
+
+const RawPreviewNode = styled.pre`
+    padding: 0.5em 1em;
+    background-color: #fafafa;
+    border-radius: 5px;
+`;
+
 const ParseHeaderRow = ({ fileContents }) => {
     if (!fileContents.headers) {
         return null;
@@ -27,21 +45,14 @@ const ParseHeaderRow = ({ fileContents }) => {
         </thead>)
 }
 
-const PreviewCellStyle = styled.td`
-text-align: center;
-&.invalid {
-    box-shadow: inset 0 0 2px 2px rgba(255,50,0,0.4);
-    padding: 8px;
-}
-`;
-
-const HasMoreCell = styled.td`
-text-align: right !important;
-`;
-
 const PreviewCell = ({ data }) => {
-    const parseable = !!parseFloat(data);
-    return (<PreviewCellStyle className={parseable ? 'valid' : 'invalid'}>{data} { !parseable && <WarningIcon/>}</PreviewCellStyle>);
+    const numberValue = parseFloat(data);
+    if (isNaN(numberValue)) {
+        // show raw value
+        return (<PreviewCellStyle className={'invalid'}>{data} <WarningIcon/></PreviewCellStyle>);
+    }
+    // show as number
+    return (<PreviewCellStyle>{numberValue}</PreviewCellStyle>);
 };
 
 const ParseDataRow = ({ fileContents }) => {
@@ -83,7 +94,13 @@ const ParseDataRow = ({ fileContents }) => {
             </tr>);
     }
     return previewRows;
-}
+};
+
+const RawPreviewRow = ({ fileContents }) => {
+    const previewLines = fileContents.lines.slice(0, Math.min(5, fileContents.lines.length));
+
+    return (<RawPreviewNode>{ previewLines.join('\r\n') + '\r\n...' }</RawPreviewNode>);
+};
 
 export const FilePreview = ({ fileContents }) => {
     if (!fileContents) {
@@ -93,12 +110,13 @@ export const FilePreview = ({ fileContents }) => {
     return (
         <ErrorBoundary hide={true}>
             <Card title={<Message messageKey='fileSettings.previewTitle' />} size="small">
-            <table>
-                <ParseHeaderRow fileContents={fileContents} />
-                <tbody>
-                    <ParseDataRow fileContents={fileContents} />
-                </tbody>
-            </table>
+                <table>
+                    <ParseHeaderRow fileContents={fileContents} />
+                    <tbody>
+                        <ParseDataRow fileContents={fileContents} />
+                    </tbody>
+                </table>
+                <RawPreviewRow fileContents={fileContents} />
             </Card>
         </ErrorBoundary>);
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
@@ -13,7 +13,7 @@ export const parseFile = (file) => {
     });
 };
 
-export const parseFileContents = (lines = [], delimiter = ';', headerLineCount = 0) => {
+export const parseFileContents = (lines = [], delimiter = ';', headerLineCount = 0, prefixColCount = 0) => {
     const headerMetadata = {
         headerLines: [],
         headers: []
@@ -23,12 +23,15 @@ export const parseFileContents = (lines = [], delimiter = ';', headerLineCount =
         const headerLines = lines.slice(0, headerLineCount);
         const headers = headerLines[0].split(delimiter).map(cell => cell.trim());
         headerMetadata.headerLines = headerLines;
-        headerMetadata.headers = headers;
+        // remove possible id column(s) at the start
+        headerMetadata.headers = headers.slice(prefixColCount);
         linesWithData = lines.slice(headerLineCount);
     }
     const decimalSeparator = detectDecimalSeparator(linesWithData[0], delimiter);
     const data = linesWithData.map(line =>
         line.split(delimiter)
+            // remove possible id column(s) at the start
+            .slice(prefixColCount)
             .map(cell => cell.trim())
             .map(cell => decimalSeparator === ',' ? cell.replace(',', '.') : cell)
             // TODO: detect non decimal cells?
@@ -39,6 +42,7 @@ export const parseFileContents = (lines = [], delimiter = ';', headerLineCount =
         // TODO: we don't need this when we don't send the file to backend
         delimiterValueForBackend: SEPARATORS.coordinateSeparator.find(sep => sep.char === delimiter)?.value,
         decimalSeparator,
+        prefixColCount,
         data,
         lines,
         ...headerMetadata

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -161,11 +161,19 @@ class UIHandler extends StateHandler {
                 [key]: value
             }
         };
-        const { fileContents } = this.getState();
-        if (fileContents) {
-            // parseFileContents() to update parsing based on the new selection
-            const coordSeparator = SEPARATORS.coordinateSeparator.find(sep => sep.value === newTypeState.import.coordinateSeparator)?.char;
-            newTypeState.fileContents = parseFileContents(fileContents.lines, coordSeparator, newTypeState.import.headerLineCount);
+        if (type === 'import') {
+            const { fileContents } = this.getState();
+            if (fileContents) {
+                // The UI is only a checkbox atm but parser takes a number of prefix columns
+                let prefixColCount = fileContents.prefixColCount;
+                if (key === 'prefixId') {
+                    prefixColCount = value ? 1 : 0;
+                }
+
+                // parseFileContents() to update parsing based on the new selection
+                const coordSeparator = SEPARATORS.coordinateSeparator.find(sep => sep.value === newTypeState.import.coordinateSeparator)?.char;
+                newTypeState.fileContents = parseFileContents(fileContents.lines, coordSeparator, newTypeState.import.headerLineCount, prefixColCount);
+            }
         }
 
         this.updateState(newTypeState);


### PR DESCRIPTION
Allow file import to use prefix column setting and show first lines of raw input data to make it easier for user to select the settings.