### PR TITLE
Komu table fixes

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/ComponentLabel.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/ComponentLabel.jsx
@@ -5,13 +5,14 @@ import { Label, Message} from 'oskari-ui';
 
 const StyledLabel = styled(Label)`
     font-weight: bold;
+    ${props => props.$height && `height: ${props.$height}px`}
 `;
 const Extra = styled.span`
     float: right;
 `;
 
-export const ComponentLabel  = ({ label, children }) => (
-    <StyledLabel>
+export const ComponentLabel  = ({ height, label, children }) => (
+    <StyledLabel $height={height}>
         <Message messageKey={label} />
         <Extra>
             { children }
@@ -20,5 +21,6 @@ export const ComponentLabel  = ({ label, children }) => (
 );
 
 ComponentLabel.propTypes = {
-    label: PropTypes.string.isRequired
+    label: PropTypes.string.isRequired,
+    height: PropTypes.number
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -100,7 +100,7 @@ const getColumns = (srs, heightSrs, controller) => {
     });
 };
 
-export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, large, controller }) => {
+export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, large, controller, page }) => {
     const dataSource = [...coordinates, ...getEmptyArray(10 - coordinates.length % 10)]; // .map((a,key) => ({...a, key }));
     const fromFile = sources.includes(ACTIONS.IMPORT);
     const optController = fromFile ? null : controller;
@@ -117,7 +117,7 @@ export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSr
                 $large={large}
                 columns={getColumns(inputSrs, inputHeightSrs, optController)}
                 dataSource={dataSource}
-                pagination={{ hideOnSinglePage: true }}/>
+                pagination={{ position: ['none'], current: page }}/>
         </Content>
     );
 };
@@ -128,10 +128,11 @@ CoordinatesTable.propTypes = {
     inputSrs: PropTypes.string,
     inputHeightSrs: PropTypes.string,
     controller: PropTypes.object.isRequired,
-    large: PropTypes.bool.isRequired
+    large: PropTypes.bool.isRequired,
+    page: PropTypes.number.isRequired
 };
 
-export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed, large }) =>  {
+export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed, large, page, controller }) =>  {
     const dataSource = [...results, ...getEmptyArray(10 - results.length % 10)]; // .map((a,key) => ({...a, key }));
     const count = coordinates.filter(coord => coord && !coord.invalid).length;
     const outdated = results.length > 0 && !transformed;
@@ -149,7 +150,13 @@ export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs,
                 $large={large}
                 columns={getColumns(outputSrs, outputHeightSrs)}
                 dataSource={dataSource}
-                pagination={{ hideOnSinglePage: true }}/>
+                pagination={{
+                    hideOnSinglePage: true,
+                    showSizeChanger: false,
+                    total: coordinates.length,
+                    current: page,
+                    onChange: page => controller.setTablePage(page)
+                }}/>
         </Content>
     );
 };
@@ -160,5 +167,7 @@ ResultsTable.propTypes = {
     outputSrs: PropTypes.string,
     outputHeightSrs: PropTypes.string,
     transformed: PropTypes.bool.isRequired,
-    large: PropTypes.bool.isRequired
+    controller: PropTypes.object.isRequired,
+    large: PropTypes.bool.isRequired,
+    page: PropTypes.number.isRequired
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Message, TextInput } from 'oskari-ui';
 import { ComponentLabel } from './ComponentLabel';
 import { Table } from 'oskari-ui/components/Table';
-import { SRS, SRS_H, SYSTEM } from '../constants';
+import { SRS, SRS_H, ACTIONS } from '../constants';
 import { getDimension } from '../helper';
 
 const COLUMNS = ['x', 'y', 'z'];
@@ -89,49 +89,55 @@ const getColumns = (srs, heightSrs, controller) => {
     });
 };
 
-export const CoordinateTable = ({ type, coordinates, srs, heightSrs, controller, editable }) => {
-    // TODO: internal state for pagination
-    // TODO: assumes pagination page size 10
+export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, controller }) => {
     const dataSource = [...coordinates, ...getEmptyArray(10 - coordinates.length % 10)]; // .map((a,key) => ({...a, key }));
-    const optController = editable ? controller : null;
+    const fromFile = sources.includes(ACTIONS.IMPORT);
+    const optController = fromFile ? null : controller;
     const count = coordinates.filter(coord => coord && !coord.invalid).length;
     return (
-        <Content className={`t_table_${type}`}>
-            <ComponentLabel label={`flyout.coordinateTable.${type}`}>
+        <Content className='t_table_input'>
+            <ComponentLabel label='flyout.coordinateTable.input'>
                 <Count className='t_row_count'>{count}</Count>
                 <Message messageKey='flyout.coordinateTable.rows' />
             </ComponentLabel>
             <StyledTable bordered
-                $editable={editable}
-                columns={getColumns(srs, heightSrs, optController)}
+                $editable={!fromFile}
+                columns={getColumns(inputSrs, inputHeightSrs, optController)}
                 dataSource={dataSource}
                 pagination={{ hideOnSinglePage: true }}/>
         </Content>
     );
 };
 
-CoordinateTable.propTypes = {
+CoordinatesTable.propTypes = {
     coordinates: PropTypes.array.isRequired,
-    srs: PropTypes.string,
-    type: PropTypes.string.isRequired,
+    sources: PropTypes.array.isRequired,
+    inputSrs: PropTypes.string,
+    inputHeightSrs: PropTypes.string,
     controller: PropTypes.object.isRequired
 };
 
-export const ResultTable = ({ coordinates, inputSrs, inputHeightSrs, results, outputSrs, outputHeightSrs }) =>  {
-    const inputCols = getColumns(inputSrs, inputHeightSrs);
-    const ouputCols = getColumns(outputSrs, outputHeightSrs);
-    let dataSource = [];
-    if (coordinates.length === results.length) {
-        dataSource = coordinates.map((coord, i) => ({ ...coord, ...results[i] }));
-    }
+export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed }) =>  {
+    const dataSource = [...results, ...getEmptyArray(10 - results.length % 10)]; // .map((a,key) => ({...a, key }));
+    const count = results.length;
     return (
-        <Content>
-            <ComponentLabel label='flyout.coordinateTable.output' />
+        <Content className='t_table_output'>
+            <ComponentLabel label='flyout.coordinateTable.output'>
+                <Count className='t_row_count'>{count}</Count>
+                <Message messageKey='flyout.coordinateTable.rows' />
+            </ComponentLabel>
             <StyledTable bordered
-                $editable={false}
-                columns={[...inputCols, ...ouputCols ]}
+                columns={getColumns(outputSrs, outputHeightSrs)}
                 dataSource={dataSource}
                 pagination={{ hideOnSinglePage: true }}/>
         </Content>
     );
+};
+
+ResultsTable.propTypes = {
+    coordinates: PropTypes.array.isRequired,
+    results: PropTypes.array.isRequired,
+    outputSrs: PropTypes.string,
+    outputHeightSrs: PropTypes.string,
+    transformed: PropTypes.bool.isRequired
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Message, TextInput } from 'oskari-ui';
+import { Message, TextInput, WarningIcon } from 'oskari-ui';
 import { ComponentLabel } from './ComponentLabel';
 import { IconButton } from 'oskari-ui/components/buttons';
 import { Table } from 'oskari-ui/components/Table';
@@ -11,6 +11,10 @@ import { getDimension } from '../helper';
 
 const COLUMNS = ['x', 'y', 'z'];
 const WIDTH = 360;
+
+const StyledWarningIcon = styled(WarningIcon)`
+    margin-right: 1em;
+`;
 
 const StyledTable = styled(Table)`
     td.ant-table-cell {
@@ -123,9 +127,13 @@ CoordinatesTable.propTypes = {
 export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed }) =>  {
     const dataSource = [...results, ...getEmptyArray(10 - results.length % 10)]; // .map((a,key) => ({...a, key }));
     const count = coordinates.filter(coord => coord && !coord.invalid).length;
+    const outdated = results.length > 0 && !transformed;
     return (
         <Content className='t_table_output'>
             <ComponentLabel label='flyout.coordinateTable.output'>
+                {outdated &&
+                    <StyledWarningIcon tooltip={<Message messageKey='flyout.coordinateTable.outdated' />} />
+                }
                 <Count className='t_row_count'>{count}</Count>
                 <Message messageKey='flyout.coordinateTable.rows' />
             </ComponentLabel>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -7,13 +7,13 @@ import { IconButton } from 'oskari-ui/components/buttons';
 import { Table } from 'oskari-ui/components/Table';
 import { SwapOutlined } from '@ant-design/icons';
 import { SRS, SRS_H, ACTIONS } from '../constants';
-import { getDimension } from '../helper';
 
 const COLUMNS = ['x', 'y', 'z'];
 const WIDTH = 360;
 
 const StyledWarningIcon = styled(WarningIcon)`
     margin-right: 1em;
+    font-size: 16px;
 `;
 
 const StyledTable = styled(Table)`
@@ -22,7 +22,11 @@ const StyledTable = styled(Table)`
         height: 24px;
         font-size: 12px;
     }
+    .ant-table-thead {
+        height: ${props => props.$large ? 52 : 34}px;
+    }
 `;
+
 const StyledInput = styled(TextInput)`
     border: none;
     font-size: 12px;
@@ -95,7 +99,7 @@ const getColumns = (srs, heightSrs, controller) => {
     });
 };
 
-export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, controller }) => {
+export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, large, controller }) => {
     const dataSource = [...coordinates, ...getEmptyArray(10 - coordinates.length % 10)]; // .map((a,key) => ({...a, key }));
     const fromFile = sources.includes(ACTIONS.IMPORT);
     const optController = fromFile ? null : controller;
@@ -109,6 +113,7 @@ export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSr
             </ComponentLabel>
             <StyledTable bordered
                 $editable={!fromFile}
+                $large={large}
                 columns={getColumns(inputSrs, inputHeightSrs, optController)}
                 dataSource={dataSource}
                 pagination={{ hideOnSinglePage: true }}/>
@@ -121,13 +126,15 @@ CoordinatesTable.propTypes = {
     sources: PropTypes.array.isRequired,
     inputSrs: PropTypes.string,
     inputHeightSrs: PropTypes.string,
-    controller: PropTypes.object.isRequired
+    controller: PropTypes.object.isRequired,
+    large: PropTypes.bool.isRequired
 };
 
-export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed }) =>  {
+export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed, large }) =>  {
     const dataSource = [...results, ...getEmptyArray(10 - results.length % 10)]; // .map((a,key) => ({...a, key }));
     const count = coordinates.filter(coord => coord && !coord.invalid).length;
     const outdated = results.length > 0 && !transformed;
+    const validLengths = coordinates.length === results.length;
     return (
         <Content className='t_table_output'>
             <ComponentLabel label='flyout.coordinateTable.output'>
@@ -138,6 +145,7 @@ export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs,
                 <Message messageKey='flyout.coordinateTable.rows' />
             </ComponentLabel>
             <StyledTable bordered
+                $large={large}
                 columns={getColumns(outputSrs, outputHeightSrs)}
                 dataSource={dataSource}
                 pagination={{ hideOnSinglePage: true }}/>
@@ -150,5 +158,6 @@ ResultsTable.propTypes = {
     results: PropTypes.array.isRequired,
     outputSrs: PropTypes.string,
     outputHeightSrs: PropTypes.string,
-    transformed: PropTypes.bool.isRequired
+    transformed: PropTypes.bool.isRequired,
+    large: PropTypes.bool.isRequired
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -50,7 +50,10 @@ const Cell = ({ value, item, onChange }) => {
     );
 };
 
-const getEmptyArray = size => [...Array(size)].map(() => ({}));
+const getFilledArray = (array, { pageSize = 10 }) => {
+    const empty = [...Array(pageSize - array.length % pageSize)].map(() => ({})); // .map((a,key) => ({...a, key }));
+    return [...array, ...empty];
+};
 
 const getColumn = (column, lonFirst, unit, dimension, editable, controller) => {
     let columnTitle = column;
@@ -100,8 +103,8 @@ const getColumns = (srs, heightSrs, controller) => {
     });
 };
 
-export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, large, controller, page }) => {
-    const dataSource = [...coordinates, ...getEmptyArray(10 - coordinates.length % 10)]; // .map((a,key) => ({...a, key }));
+export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSrs, large, pagination, controller }) => {
+    const dataSource = getFilledArray(coordinates, pagination);
     const fromFile = sources.includes(ACTIONS.IMPORT);
     const optController = fromFile ? null : controller;
     return (
@@ -117,7 +120,7 @@ export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSr
                 $large={large}
                 columns={getColumns(inputSrs, inputHeightSrs, optController)}
                 dataSource={dataSource}
-                pagination={{ position: ['none'], current: page }}/>
+                pagination={{ position: ['none'], ...pagination }}/>
         </Content>
     );
 };
@@ -129,11 +132,11 @@ CoordinatesTable.propTypes = {
     inputHeightSrs: PropTypes.string,
     controller: PropTypes.object.isRequired,
     large: PropTypes.bool.isRequired,
-    page: PropTypes.number.isRequired
+    pagination: PropTypes.object.isRequired
 };
 
-export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed, large, page, controller }) =>  {
-    const dataSource = [...results, ...getEmptyArray(10 - results.length % 10)]; // .map((a,key) => ({...a, key }));
+export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed, large, pagination, controller }) =>  {
+    const dataSource = getFilledArray(results, pagination);
     const count = coordinates.filter(coord => coord && !coord.invalid).length;
     const outdated = results.length > 0 && !transformed;
     const validLengths = coordinates.length === results.length;
@@ -151,11 +154,11 @@ export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs,
                 columns={getColumns(outputSrs, outputHeightSrs)}
                 dataSource={dataSource}
                 pagination={{
+                    ...pagination,
                     hideOnSinglePage: true,
                     showSizeChanger: false,
                     total: coordinates.length,
-                    current: page,
-                    onChange: page => controller.setTablePage(page)
+                    onChange: (page, pageSize) => controller.setPagination(page, pageSize)
                 }}/>
         </Content>
     );
@@ -169,5 +172,5 @@ ResultsTable.propTypes = {
     transformed: PropTypes.bool.isRequired,
     controller: PropTypes.object.isRequired,
     large: PropTypes.bool.isRequired,
-    page: PropTypes.number.isRequired
+    pagination: PropTypes.object.isRequired
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -10,6 +10,7 @@ import { SRS, SRS_H, ACTIONS } from '../constants';
 
 const COLUMNS = ['x', 'y', 'z'];
 const WIDTH = 360;
+const LABEL_HEIGHT = 34;
 
 const StyledWarningIcon = styled(WarningIcon)`
     margin-right: 1em;
@@ -105,7 +106,7 @@ export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSr
     const optController = fromFile ? null : controller;
     return (
         <Content className='t_table_input'>
-            <ComponentLabel label='flyout.coordinateTable.input'>
+            <ComponentLabel height={LABEL_HEIGHT} label='flyout.coordinateTable.input'>
                 <IconButton
                     icon={<SwapOutlined />}
                     title={<Message messageKey='actions.axisFlip'/>}
@@ -137,7 +138,7 @@ export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs,
     const validLengths = coordinates.length === results.length;
     return (
         <Content className='t_table_output'>
-            <ComponentLabel label='flyout.coordinateTable.output'>
+            <ComponentLabel height={LABEL_HEIGHT} label='flyout.coordinateTable.output'>
                 {outdated &&
                     <StyledWarningIcon tooltip={<Message messageKey='flyout.coordinateTable.outdated' />} />
                 }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Message, TextInput } from 'oskari-ui';
 import { ComponentLabel } from './ComponentLabel';
+import { IconButton } from 'oskari-ui/components/buttons';
 import { Table } from 'oskari-ui/components/Table';
+import { SwapOutlined } from '@ant-design/icons';
 import { SRS, SRS_H, ACTIONS } from '../constants';
 import { getDimension } from '../helper';
 
@@ -93,12 +95,13 @@ export const CoordinatesTable = ({ coordinates, sources, inputSrs, inputHeightSr
     const dataSource = [...coordinates, ...getEmptyArray(10 - coordinates.length % 10)]; // .map((a,key) => ({...a, key }));
     const fromFile = sources.includes(ACTIONS.IMPORT);
     const optController = fromFile ? null : controller;
-    const count = coordinates.filter(coord => coord && !coord.invalid).length;
     return (
         <Content className='t_table_input'>
             <ComponentLabel label='flyout.coordinateTable.input'>
-                <Count className='t_row_count'>{count}</Count>
-                <Message messageKey='flyout.coordinateTable.rows' />
+                <IconButton
+                    icon={<SwapOutlined />}
+                    title={<Message messageKey='actions.axisFlip'/>}
+                    onClick={() => controller.swapCoordinates()} />
             </ComponentLabel>
             <StyledTable bordered
                 $editable={!fromFile}
@@ -119,7 +122,7 @@ CoordinatesTable.propTypes = {
 
 export const ResultsTable = ({ coordinates, results, outputSrs, outputHeightSrs, transformed }) =>  {
     const dataSource = [...results, ...getEmptyArray(10 - results.length % 10)]; // .map((a,key) => ({...a, key }));
-    const count = results.length;
+    const count = coordinates.filter(coord => coord && !coord.invalid).length;
     return (
         <Content className='t_table_output'>
             <ComponentLabel label='flyout.coordinateTable.output'>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/CoordinateTable.jsx
@@ -19,8 +19,8 @@ const StyledWarningIcon = styled(WarningIcon)`
 
 const StyledTable = styled(Table)`
     td.ant-table-cell {
-        ${props => props.$editable && 'padding: 0 !important;'}
-        height: 24px;
+        padding: ${props => props.$editable ? '0px' : '4px 8px 2px'} !important;
+        height: 26px;
         font-size: 12px;
     }
     .ant-table-thead {
@@ -30,6 +30,7 @@ const StyledTable = styled(Table)`
 
 const StyledInput = styled(TextInput)`
     border: none;
+    padding: 4px 8px 2px;
     font-size: 12px;
 `;
 const Count = styled.span`

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/SrsSelect.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/SrsSelect.jsx
@@ -42,7 +42,9 @@ const Srs = ({ srs, options, onChange, controller, block = false }) => {
 
 export const SrsSelect = ({ srs, heightSrs, type, minimal, controller }) => {
     const heightDisabled = getDimension(srs) === 3;
-    const heightPH = <Message messageKey='flyout.coordinateSystem.heightSystem.none' />;
+    const heightPH = heightDisabled
+        ? SRS_OPTIONS.find(s => s.value === srs)?.label
+        : <Message messageKey='flyout.coordinateSystem.heightSystem.none' />;
     if (minimal) {
         return (
             <Content className={`t_srs_${type}`}>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/constants.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/constants.js
@@ -24,6 +24,11 @@ export const MARKER = {
     size: 3
 };
 
+export const PAGINATION = {
+    current: 1,
+    pageSize: 10
+};
+
 export const FILE_DEFAULTS = {
     import: {
         headerLineCount: 0,

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -342,7 +342,7 @@ class UIHandler extends StateHandler {
     }
 
     showOnMap () {
-        const { coordinates, inputSrs } = this.getState(); //  inputSrs, source
+        const { coordinates, inputSrs, pagination } = this.getState();
         if (this.mapPopup) {
             return;
         }
@@ -352,8 +352,12 @@ class UIHandler extends StateHandler {
             this.showInfoMessage(title, msg);
             return;
         }
+        const { current, pageSize } = pagination;
+        const end = current * pageSize;
+        const start = end - pageSize;
+        const toShow = coordinates.slice(start, end);
         // TODO: convert to map projection (axis order) and add label (source !== map)
-        this.instance.setMapCoordinates(coordinates);
+        this.instance.setMapCoordinates(toShow);
         this.instance.toggleFlyout(false);
         this.mapPopup = showMapPreviewPopup(() => this.closeMapPopup(true));
     }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -5,7 +5,7 @@ import { showConfirmPopup } from '../view/ConfirmPopup';
 import { showClipboardPopup } from '../view/ClipboardPopup';
 import { showMapSelectPopup, showMapPreviewPopup } from '../view/MapPopup';
 import { SOURCE, MAP, WATCH_JOB, WATCH_URL, TRANSFORM, FILE_DEFAULTS, SEPARATORS, ACTIONS, PAGINATION } from '../constants';
-import { stateToPTIArray, loadFile, validateTransform, validateFileSettings, parseCoordinateValue, is3DSystem } from '../helper';
+import { stateToPTIArray, loadFile, validateTransform, validateFileSettings, parseCoordinateValue, is3DSystem, getLabelForMarker } from '../helper';
 import { parseFile, parseFileContents } from './FileParser';
 
 const getInitialState = () => ({
@@ -356,10 +356,27 @@ class UIHandler extends StateHandler {
         const end = current * pageSize;
         const start = end - pageSize;
         const toShow = coordinates.slice(start, end);
-        // TODO: convert to map projection (axis order) and add label (source !== map)
-        this.instance.setMapCoordinates(toShow);
-        this.instance.toggleFlyout(false);
-        this.mapPopup = showMapPreviewPopup(() => this.closeMapPopup(true));
+        const mapSrs = this.sandbox.getMap().getSrsName();
+
+        const callback = mapCoords => {
+            const labeled = mapCoords.map((coord, i) => {
+                // Use original coords and srs for label
+                const label = getLabelForMarker(toShow[i], inputSrs);
+                return { ...coord, label };
+            });
+            this.instance.setMapCoordinates(labeled);
+            this.instance.toggleFlyout(false);
+            this.mapPopup = showMapPreviewPopup(() => this.closeMapPopup(true));
+        };
+        if (mapSrs === inputSrs) {
+            callback(toShow);
+        } else {
+            this.transformToMapSrs({
+                coordinates: toShow,
+                inputSrs,
+                outputSrs: mapSrs
+            },callback);
+        }
     }
 
     selectFromMap () {
@@ -524,6 +541,34 @@ class UIHandler extends StateHandler {
         this.updateState({ coordinates, sources: [ACTIONS.IMPORT] });
     }
 
+    transformToMapSrs (values, callback) {
+        const state = { ...this.getState(), ...values };
+        if (this.validate('inputSrs')) {
+            return;
+        }
+        this.updateState({ loading: true });
+        const { params, body } = stateToPTIArray(state, 'A2A', false);
+        fetch(Oskari.urls.getRoute('CoordinateTransformation', params), {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json'
+            },
+            body
+        }).then(response => {
+            return response.json();
+        }).then(json => {
+            const { jobId } = json;
+            if (jobId) {
+                this.watchJsonJob(jobId, callback);
+            } else {
+                this.showResponseError(json);
+            }
+        }).catch((e) => {
+            Messaging.error(this.loc('flyout.transform.responseErrors.generic'));
+            this.updateState({ loading: false });
+        });
+    }
+
     transformToArray (transformType) {
         const state = this.getState();
         if (this.validate(transformType)) {
@@ -557,7 +602,8 @@ class UIHandler extends StateHandler {
         });
     }
 
-    watchJsonJob (jobId) {
+    // For now use same function for show on map transformation
+    watchJsonJob (jobId, callback) {
         fetch(Oskari.urls.getLocation(WATCH_JOB) + jobId, {
             method: 'GET',
             headers: {
@@ -576,7 +622,12 @@ class UIHandler extends StateHandler {
             } else if (resultCoordinates) {
                 // TODO: can undefined z cause problems??
                 const results = resultCoordinates.map(([x, y, z]) => ({ x, y, z }));
-                this.updateState({ loading: false, results, transformed: true });
+                if (typeof callback === 'function') {
+                    this.updateState({ loading: false });
+                    callback(results);
+                } else {
+                    this.updateState({ loading: false, results, transformed: true });
+                }
             } else {
                 this.showResponseError(json);
             }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -4,7 +4,7 @@ import { showFilePopup } from '../view/FilePopup';
 import { showConfirmPopup } from '../view/ConfirmPopup';
 import { showClipboardPopup } from '../view/ClipboardPopup';
 import { showMapSelectPopup, showMapPreviewPopup } from '../view/MapPopup';
-import { SOURCE, MAP, WATCH_JOB, WATCH_URL, TRANSFORM, FILE_DEFAULTS, SEPARATORS, ACTIONS } from '../constants';
+import { SOURCE, MAP, WATCH_JOB, WATCH_URL, TRANSFORM, FILE_DEFAULTS, SEPARATORS, ACTIONS, PAGINATION } from '../constants';
 import { stateToPTIArray, loadFile, validateTransform, validateFileSettings, parseCoordinateValue, is3DSystem } from '../helper';
 import { parseFile, parseFileContents } from './FileParser';
 
@@ -23,7 +23,7 @@ const getInitialState = () => ({
     coordinates: [],
     results: [],
     transformed: false, // set false if coordinates or srs selections are updated
-    tablePage: 1
+    pagination: { ...PAGINATION }
 });
 
 class UIHandler extends StateHandler {
@@ -244,8 +244,9 @@ class UIHandler extends StateHandler {
         this.updateState({ [prop]: srs, transformed: false });
     }
 
-    setTablePage (tablePage) {
-        this.updateState({ tablePage });
+    setPagination (current, pageSize) {
+        const { pagination } = this.getState();
+        this.updateState({ pagination: { ...pagination, current } });
     }
 
     setFiles (files = []) {
@@ -637,7 +638,7 @@ const wrapped = controllerMixin(UIHandler, [
     'importFileContentsToInputTable',
     'addFromSource',
     'swapCoordinates',
-    'setTablePage'
+    'setPagination'
 ]);
 
 export { wrapped as ViewHandler };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -241,6 +241,10 @@ class UIHandler extends StateHandler {
 
     setHeightSrs (type, srs) {
         const prop = `${type}HeightSrs`;
+        if (srs === 'EPSG:8675') {
+            // TODO: url isn't added because it did't work, find working url and refactor showInfoMessage
+            this.showInfoMessage('flyout.coordinateSystem.heightSystem.label', 'flyout.coordinateSystem.heightSystem.n43.info');
+        }
         this.updateState({ [prop]: srs, transformed: false });
     }
 

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -22,7 +22,8 @@ const getInitialState = () => ({
     export: { ...FILE_DEFAULTS.export },
     coordinates: [],
     results: [],
-    transformed: false // set false if coordinates or srs selections are updated
+    transformed: false, // set false if coordinates or srs selections are updated
+    tablePage: 1
 });
 
 class UIHandler extends StateHandler {
@@ -241,6 +242,10 @@ class UIHandler extends StateHandler {
     setHeightSrs (type, srs) {
         const prop = `${type}HeightSrs`;
         this.updateState({ [prop]: srs, transformed: false });
+    }
+
+    setTablePage (tablePage) {
+        this.updateState({ tablePage });
     }
 
     setFiles (files = []) {
@@ -631,7 +636,8 @@ const wrapped = controllerMixin(UIHandler, [
     'validate',
     'importFileContentsToInputTable',
     'addFromSource',
-    'swapCoordinates'
+    'swapCoordinates',
+    'setTablePage'
 ]);
 
 export { wrapped as ViewHandler };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -148,10 +148,10 @@ class UIHandler extends StateHandler {
     }
 
     updateCoordinate (index, coordinate) {
-        const coordinates = [...this.getState().coordinates];
-        // TODO: validate x,y,z getDimension (remove keys with empty value??)
-        coordinates[index] = coordinate;
-        // const updated = coordinates.map((c, i) => i === index ? coordinate : c);
+        const updated = [...this.getState().coordinates];
+        updated[index] = coordinate;
+        // fill empty/undefined with object
+        const coordinates = updated.map(c => c ? c : { invalid: true });
         this.addSourceToState('table');
         this.updateState({ coordinates, transformed: false });
     }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -181,6 +181,12 @@ class UIHandler extends StateHandler {
         this.updateCoordinate(index, updated);
     }
 
+    swapCoordinates () {
+        const { coordinates } = this.getState();
+        const swapped = coordinates.map(c => ({ ...c, x: c.y, y: c.x }));
+        this.updateState({ coordinates: swapped })
+    }
+
     // TODO: refactor
     setSrs (type, srs, forced) {
         if (type === 'input' && !forced) {
@@ -624,7 +630,8 @@ const wrapped = controllerMixin(UIHandler, [
     'reset',
     'validate',
     'importFileContentsToInputTable',
-    'addFromSource'
+    'addFromSource',
+    'swapCoordinates'
 ]);
 
 export { wrapped as ViewHandler };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -321,6 +321,7 @@ class UIHandler extends StateHandler {
         if (id === 'store') {
             const coordinates = this.instance.getMapCoordinates();
             this.instance.setMapSelectionMode();
+            this.addSourceToState(ACTIONS.MAP)
             this.updateState({ coordinates, transformed: false });
         }
         if (Object.values(MAP).includes(id)) {
@@ -503,7 +504,8 @@ class UIHandler extends StateHandler {
             return;
         }
         const coordinates = fileContents.data.map(([x, y, z]) => ({ x, y, z }));
-        this.updateState({ coordinates });
+        // sets all coordinates from file so one source only
+        this.updateState({ coordinates, sources: [ACTIONS.IMPORT] });
     }
 
     transformToArray (transformType) {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -574,6 +574,7 @@ class UIHandler extends StateHandler {
     }
 
     transformToArray (transformType) {
+        // TODO: confirm 2Dto3D and 3Dto2D (transform.warnings)
         const state = this.getState();
         if (this.validate(transformType)) {
             return;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -45,10 +45,15 @@ export const validateTransform = (state, type) => {
     return ['message'];
 };
 const validateSelections = (state) => {
+    const { inputSrs, outputSrs, inputHeightSrs } = state;
     const errors = [];
     // TODO: set import, set export, transform => split ??
-    if (!state.inputSrs || !state.outputSrs) {
+    if (!inputSrs || !outputSrs) {
         errors.push('crs');
+    }
+    const { system } = SRS.find(s => s.value === outputSrs) || {};
+    if (getDimension(inputSrs, inputHeightSrs) !== 3 && system === 'PROJ_3D') {
+        errors.push('xyz');
     }
     return errors;
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -147,7 +147,6 @@ export const getSystemsFromCompound = (epsg) => {
     return null;
 };
 
-// TODO: pass mapmodule or move to service/maphelper??
 export const isCoordInBounds = (srs, coord) => {
     const { lonFirst, bounds } = SRS.find(s => s.value === srs);
     const map = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
@@ -184,36 +183,38 @@ export const moveMapToMarkers = (state) => {
     }
 };
 
-// TODO: refactor
-export const getLabelForMarker = (lonlat, epsgValues, isAxisFlip) => {
-    let lonLabel;
-    let latLabel;
-    const val = epsgValues || this.mapEpsgValues;
-    const lonFirst = isAxisFlip ? !val.lonFirst : val.lonFirst;
-    if (val.coord === 'PROJ_3D') {
-        return 'X: ' + lonlat.lon + ', Y: ' + lonlat.lat + ', Z: ' + lonlat.height;
+export const getLabelForMarker = (coord, srs) => {
+    const { axes } = SRS.find(s => s.value === srs) || {};
+    const { x, y, z } = coord;
+    if (!axes) {
+        return `${x}, ${y}${z ? ', z' : ''}`;
     }
-    if (val.coord === 'GEOG_2D' || val.coord === 'GEOG_3D') {
-        lonLabel = this.loc('mapMarkers.show.lon');
-        latLabel = this.loc('mapMarkers.show.lat');
-    } else {
-        lonLabel = this.loc('mapMarkers.show.east');
-        latLabel = this.loc('mapMarkers.show.north');
+    // Table columns x, y, z always
+    const labels = axes.map(axis => {
+        if (axis === 'φ') {
+            return 'Lat';
+        }
+        if (axis === 'λ') {
+            return 'Lon';
+        }
+        return axis;
+    });
+    const decimal = Oskari.getDecimalSeparator();
+    const values = [x, y, z].map(c => `${c || ''}`.replace('.', decimal));
+    return labels.map((label, i) => `${label}: ${values[i]}`).join(', ');
+    /*
+    const [xLabel, yLabel, zLabel] = labels;
+    if (zLabel) {
+        return `${xLabel}: ${x}, ${yLabel}: ${y}, ${zLabel}: ${y}`;
     }
-    // TODO do we need to localize decimal separator for label
-    // Oskari.getDecimalSeparator();
-    // lon = coords[].replace('.', Oskari.getDecimalSeparator());
-    if (lonFirst) {
-        return lonLabel + ': ' + lonlat.lon + ', ' + latLabel + ': ' + lonlat.lat;
-    } else {
-        return latLabel + ': ' + lonlat.lat + ', ' + lonLabel + ': ' + lonlat.lon;
-    }
+    return `${xLabel}: ${x}, ${yLabel}: ${y}`;
+    */
 };
 
 export const coordinateToMarker = (coord, isNew) => {
     const { colors, ...props } = MARKER;
     const { x, y, label } = coord;
-    const msg = label || `E: ${x}, N: ${y}`;
+    const msg = label || `E: ${x}, N: ${y}`; // default to map E, N
     const color = isNew ? colors.new : colors.old;
     return { ...props, x, y, msg, color };
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -148,15 +148,14 @@ export const getSystemsFromCompound = (epsg) => {
 };
 
 export const isCoordInBounds = (srs, coord) => {
-    const { lonFirst, bounds } = SRS.find(s => s.value === srs);
-    const map = Oskari.getSandbox().findRegisteredModuleInstance('MainMapModule');
-    if (!bounds || !map) {
-        return false;
+    const { bounds } = SRS.find(s => s.value === srs) || {};
+    if (!bounds || bounds.length !== 4) {
+        return true;
     }
-    const x = lonFirst ? coord[0] : coord[1];
-    const y = lonFirst ? coord[1] : coord[0];
-    return map.isPointInExtent(bounds, x, y);
+    const { x, y } = coord;
+    return bounds[0] <= x && x <= bounds[2] && bounds[1] <= y && y <= bounds[3];
 };
+
 // TODO: pass mapmodule or move to service/maphelper??
 export const moveMapToMarkers = (state) => {
     // TODO: use converted map coordinates, this works only for native srs

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -182,6 +182,7 @@ Oskari.registerLocalization(
             "export": "Save to file",
             "minimizeSrs": "Hide coordinate reference system extra selections",
             "minimizedSrs": "Show all coordinate reference system selections",
+            "axisFlip": "Coordinates reversed",
             "search": "Search using name or EPSG code",
             "select": "Select",
             "cancel": "Cancel",
@@ -207,7 +208,7 @@ Oskari.registerLocalization(
                 "coordinateSeparator": "Field separator",
                 "headerCount": "Number of header rows",
                 "decimalPrecision": "Decimal precision",
-                "reverseCoordinates": "Coordinates reversed",
+                "axisFlip": "Coordinates reversed",
                 "useId": { // Use identifier, Use id infront
                     "input": "Coordinates contain identifiers",
                     "generate": "Create identifers",
@@ -387,7 +388,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "reverseCoordinates":{
+            "axisFlip":{
                 "title":"Reversed coordinates",
                 "info": "",
                 "paragraphs": [

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -80,6 +80,7 @@ Oskari.registerLocalization(
                 "input": "Coordinates to be transformed",
                 "output": "Result coordinates",
                 "rows": "Rows",
+                "outdated": "The selections or coordinates have changed. Transform coordinates to get updated results.",
                 "clearTables": "Remove all coordinates",
                 "confirmClear": "Are you sure you want to remove all coordinates from tables?"
             },

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -165,11 +165,7 @@ Oskari.registerLocalization(
                 "info" : "The coordinate reference system of the map is ETRS-TM35FIN. Coordinates have been placed on the map using this coordinate reference system. With the location, the coordinates are shown numerically in the input and/or output coordinate reference system. ",
                 "errorTitle": "Error in showing positions",
                 "noCoordinates": "No coordinates available to be shown on the map",
-                "noSrs": "A geodetic coordinate reference system must be selected in input properties in order to show points on the map.",
-                "lon": "Lon",
-                "lat": "Lat",
-                "north": "N",
-                "east": "E"
+                "noSrs": "A geodetic coordinate reference system must be selected in input properties in order to show points on the map."
             },
             "select":{
                 "title": "Select locations on the map",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -89,12 +89,12 @@ Oskari.registerLocalization(
                     "title": "Warning!",
                     "3DTo2D": "The selected input information contains height values, but the output information does not. Output coordinates will therefore not include height values. Do you want to continue?",
                     "2DTo3D": "The selected output information contains height values, but the input information does not. The height values 0 and height system N2000 will be added to the input information. Do you want to continue?",
-                    "xyz": "No height system has been selected for the input coordinate system. It is not possible to transform this input information into a projected 3D system.",
                     "largeFile": "The transformation of large files can take several minutes."
                 },
                 "validateErrors": {
                     "title": "Error!", // Error in coordinate system selections
                     "message": "Selections are incomplete or contain errors. Note the following requirements and try again.",
+                    "xyz": "No height system has been selected for the input coordinate system. It is not possible to transform this input information into a projected 3D system.",
                     "crs": "A geodetic coordinate reference system must be selected both in the input and the output information.",
                     "noInputData": "No input coordinates.",
                     "noInputFile": "The file containing input information must be selected.",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -85,6 +85,7 @@ Oskari.registerLocalization(
                 "input": "Muunnettavat lähtökoordinaatit",
                 "output": "Tuloskoordinaatit",
                 "rows": "Riviä",
+                "outdated": "Valinnat tai koordinatit muuttuneet. Muunna koordinaatit, jotta tulokset päivittyvät.",
                 "clearTables": "Poista kaikki koordinaatit",
                 "confirmClear": "Haluatko poistaa taulukoista kaikki koordinaatit?"
             },

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -94,12 +94,12 @@ Oskari.registerLocalization(
                     "title": "Huomio!",
                     "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
                     "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?",
-                    "xyz": "Lähtökoordinaattijärjestelmän valinnoissa ei ole korkeusjärjestelmää. Muunnos suorakulmaiseen 3D -järjestelmään ei ole mahdollinen.",
                     "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
                 },
                 "validateErrors": {
                     "title": "Virhe!",
                     "message": "Valinnoissa on puutteita tai virheitä. Ota huomioon seuraavat vaatimukset ja yritä uudelleen.",
+                    "xyz": "Lähtökoordinaattijärjestelmän valinnoissa ei ole korkeusjärjestelmää. Muunnos suorakulmaiseen 3D -järjestelmään ei ole mahdollinen.",
                     "crs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna sekä lähtö- että tulostiedoissa.",
                     "srs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna.",
                     "noInputData": "Ei muunnettavia koordinaatteja.",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -189,6 +189,7 @@ Oskari.registerLocalization(
             "export": "Tallenna tiedostoon",
             "minimizeSrs": "Piilota koordinaattjijärjestelmän lisävalinnat",
             "minimizedSrs": "Näytä kaikki koordinaattjijärjestelmän valinnat",
+            "axisFlip": "Koordinaatit käänteisesti",
             "search": "Hae nimellä tai EPSG-koodilla",
             "select": "Valitse",
             "cancel": "Peruuta",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -172,11 +172,7 @@ Oskari.registerLocalization(
                 "info": "Kartta on ETRS-TM35FIN-koordinaattijärjestelmässä. Koordinaatit on sijoitettu kartalle kyseistä koordinaattijärjestelmää käyttäen. Sijaintimerkinnän yhteydessä näytään lähtö- ja/tai tuloskoordinaattijärjestelmän mukaiset koordinaatit lukemina. ",
                 "errorTitle": "Virhe sijaintien näyttämisessä",
                 "noCoordinates": "Ei koordinaatteja näytettäväksi kartalla",
-                "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla.",
-                "lon": "Lon",
-                "lat": "Lat",
-                "north": "N",
-                "east": "E"
+                "noSrs": "Geodeettinen koordinaattijärjestelmä pitää olla valittuna lähtötiedoissa, jotta pisteet voidaan näyttää kartalla."
             },
             "select":{
                 "title": "Valitse sijainnit kartalta",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -80,6 +80,7 @@ Oskari.registerLocalization(
                 "input": "Koordinater som ska transformeras",
                 "output": "Resultatkoordinater",
                 "rows": "Rader",
+                "outdated": "Valen eller koordinaterna har ändrats. Transformera koordinaterna för att få uppdaterade resultat.",
                 "clearTables": "Ta bort alla koordinater",
                 "confirmClear": "Är du säker på att du vill ta bort alla koordinater från tabellerna?"
             },

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -165,11 +165,7 @@ Oskari.registerLocalization(
                 "info" : "Kartans referenssystem för koordinater är ETRS-TM35FIN. Koordinaterna har placerats på kartan med hjälp av detta referenssystem för koordinater. I samband med lägesanteckningen anges koordinaterna enligt utgångs- och/eller resultatreferenssystemet i siffror.",
                 "errorTitle": "Fel i visningen av positioner",
                 "noCoordinates": "Det finns inga koordinater att visa på kartan.",
-                "noSrs": "Ett geodetiskt referenssystem för koordinater måste ingå i utgångsuppgifterna för att kunna visa punkter på kartan.",
-                "lon": "Lon",
-                "lat": "Lat",
-                "north": "N",
-                "east": "E"
+                "noSrs": "Ett geodetiskt referenssystem för koordinater måste ingå i utgångsuppgifterna för att kunna visa punkter på kartan."
             },
             "select":{
                 "title": "Välj lägen på kartan",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -89,12 +89,12 @@ Oskari.registerLocalization(
                     "title": "Observera!",
                     "3DTo2D": "I de utgångsuppgifter du valt finns höjdvärden, men inte i resultatuppgifterna. Höjvärden ingår alltså inte i resultatkoordinaterna. Vill du fortsätta?",
                     "2DTo3D": "I de resultatuppgifter du valt finns höjdvärden, men inte i utgångsuppgifterna. Utgångsmaterialet ges höjdvärdet 0 och höjdsystemet N2000. Vill du fortsätta?",
-                    "xyz": "I valen som berör utgångsreferenssystemet för koordinater finns inget höjdsystem. En omvandling till ett kartesiskt 3D-system kan inte göras.",
                     "largeFile": "Transformation av stora filer kan ta flera minuter."
                 },
                 "validateErrors": {
                     "title": "Fel!",
                     "message": "Det finns brister eller fel i valen. Beakta följande krav och försök på nytt.",
+                    "xyz": "I valen som berör utgångsreferenssystemet för koordinater finns inget höjdsystem. En omvandling till ett kartesiskt 3D-system kan inte göras.",
                     "crs": "Ett geodetiskt referenssystem för koordinater ska vara valt både i utgångs- och resultatuppgifterna.",
                     "noInputData": "Det finns inga koordinater som kan transformeras.",
                     "noInputFile": "Filen som innehåller utgångsmaterial ska vara vald.",

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -182,6 +182,7 @@ Oskari.registerLocalization(
             "export": "Spara till fil",
             "minimizeSrs": "Dölj extra val för koordinatreferenssystem",
             "minimizedSrs": "Visa alla val av koordinatreferenssystem",
+            "axisFlip": "Omvända koordinater",
             "search": "Sök med namn eller EPSG-kod",
             "select": "Välj",
             "cancel": "Avbryt", //Ångra
@@ -207,7 +208,7 @@ Oskari.registerLocalization(
                 "coordinateSeparator": "Skiljetecken för fält",
                 "headerCount": "Antal rubrikrader",
                 "decimalCount": "Decimalernas precision",
-                "reverseCoordinates": "Omvända koordinater",
+                "axisFlip": "Omvända koordinater",
                 "useId": { // Använd identifierare
                     "input": "Koordinater innehåller identifierare",
                     "generate": "Skapa identifierare",
@@ -386,7 +387,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "reverseCoordinates":{
+            "axisFlip":{
                 "title":"Omvända koordinater",
                 "info": "X- och Y-koordinataxlarnas ordning avviker från den definierade ordningen.",
                 "paragraphs": [

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
@@ -4,9 +4,8 @@ import styled from 'styled-components';
 import { Message, Button} from 'oskari-ui';
 import { ButtonContainer } from 'oskari-ui/components/buttons';
 import { SourceButtons } from '../components/SourceSelect.jsx';
-import { CoordinateTable } from '../components/CoordinateTable.jsx';
+import { CoordinatesTable, ResultsTable } from '../components/CoordinateTable.jsx';
 import { SrsSelect } from '../components/SrsSelect';
-import { ClearTableButton } from '../components/ClearTableButton';
 import { MandatoryDescription } from '../components/MandatoryDescription';
 
 const Content = styled.div`
@@ -31,6 +30,7 @@ const StyledButtonContainer = styled(ButtonContainer)`
 export const FlyoutContent = ({
     controller,
     source,
+    sources,
     coordinates,
     results,
     inputSrs,
@@ -55,8 +55,8 @@ export const FlyoutContent = ({
             </div>
             <SourceButtons controller={controller} />
             <Splitter>
-                <CoordinateTable type='input' editable={source === 'table'} srs={inputSrs} heightSrs={inputHeightSrs} coordinates={coordinates} controller={controller} />
-                <CoordinateTable type='output' srs={outputSrs} heightSrs={outputHeightSrs} coordinates={results} controller={controller} />
+                <CoordinatesTable inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
+                <ResultsTable outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} />
             </Splitter>
             
             <StyledButtonContainer>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
@@ -7,6 +7,7 @@ import { SourceButtons } from '../components/SourceSelect.jsx';
 import { CoordinatesTable, ResultsTable } from '../components/CoordinateTable.jsx';
 import { SrsSelect } from '../components/SrsSelect';
 import { MandatoryDescription } from '../components/MandatoryDescription';
+import { getDimension } from '../helper';
 
 const Content = styled.div`
     display: flex;
@@ -41,6 +42,8 @@ export const FlyoutContent = ({
 }) => {
     const [ minimalSrs, setMinimalSrs ] = useState(true);
     const transformType = source === 'file' ? 'F2A' : 'A2A';
+    // Have to check here to use same height for input & output table headers
+    const transform3D = getDimension(inputSrs, inputHeightSrs) === 3 || getDimension(outputSrs, outputHeightSrs) === 3;
     return (
         <Content>
             <MandatoryDescription/>
@@ -55,8 +58,8 @@ export const FlyoutContent = ({
             </div>
             <SourceButtons controller={controller} />
             <Splitter>
-                <CoordinatesTable inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
-                <ResultsTable outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} />
+                <CoordinatesTable large={transform3D} inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
+                <ResultsTable large={transform3D} outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} />
             </Splitter>
             
             <StyledButtonContainer>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
@@ -39,7 +39,7 @@ export const FlyoutContent = ({
     outputHeightSrs,
     outputSrs,
     transformed,
-    tablePage
+    pagination
 }) => {
     const [ minimalSrs, setMinimalSrs ] = useState(true);
     const transformType = source === 'file' ? 'F2A' : 'A2A';
@@ -59,8 +59,8 @@ export const FlyoutContent = ({
             </div>
             <SourceButtons controller={controller} />
             <Splitter>
-                <CoordinatesTable large={transform3D} page={tablePage} inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
-                <ResultsTable large={transform3D} page={tablePage} outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} controller={controller}/>
+                <CoordinatesTable large={transform3D} pagination={pagination} inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
+                <ResultsTable large={transform3D} pagination={pagination} outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} controller={controller}/>
             </Splitter>
             
             <StyledButtonContainer>

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
@@ -38,7 +38,8 @@ export const FlyoutContent = ({
     inputHeightSrs,
     outputHeightSrs,
     outputSrs,
-    transformed
+    transformed,
+    tablePage
 }) => {
     const [ minimalSrs, setMinimalSrs ] = useState(true);
     const transformType = source === 'file' ? 'F2A' : 'A2A';
@@ -58,8 +59,8 @@ export const FlyoutContent = ({
             </div>
             <SourceButtons controller={controller} />
             <Splitter>
-                <CoordinatesTable large={transform3D} inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
-                <ResultsTable large={transform3D} outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} />
+                <CoordinatesTable large={transform3D} page={tablePage} inputSrs={inputSrs} inputHeightSrs={inputHeightSrs} coordinates={coordinates} sources={sources} controller={controller} />
+                <ResultsTable large={transform3D} page={tablePage} outputSrs={outputSrs} outputHeightSrs={outputHeightSrs} coordinates={coordinates} results={results} transformed={transformed} controller={controller}/>
             </Splitter>
             
             <StyledButtonContainer>
@@ -93,5 +94,7 @@ FlyoutContent.propTypes = {
     file: PropTypes.any,
     coordinates: PropTypes.array.isRequired,
     results: PropTypes.array.isRequired,
+    transformed: PropTypes.bool.isRequired,
+    tablePage: PropTypes.number.isRequired,
     controller: PropTypes.object.isRequired
 };


### PR DESCRIPTION
- Fix table size and alignment by reserving space for headers and adjusting cell height and paddings.
- Split input and output tables to own components
- Use same pagination for both tables and show coordinates on map
- Add swap icon for reverse coordinates
- Add warning icon if result coordinates are outdated (srs or input coordinates updated)
- Show EPSG values as select option title
- Transform input coordinates to map srs on show coordinates on map
- prevent 2D to XYX transform
- Add info popup for N43