### PR TITLE
Komu confirm transform

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/constants.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/constants.js
@@ -3,7 +3,6 @@ export const WATCH_JOB = 'CoordinateTransformJob';
 export const WATCH_URL = '/coordinatetransform/watch/';
 export const ID_PREFIX = 'coord_marker_';
 export const SOURCE = ['table', 'file', 'map'];
-export const TRANSFORM = ['A2A', 'F2A', 'F2R', 'F2F', 'A2F'];
 export const MAP = {
     ADD: 'add',
     REMOVE: 'remove'

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -4,8 +4,8 @@ import { showFilePopup } from '../view/FilePopup';
 import { showConfirmPopup } from '../view/ConfirmPopup';
 import { showClipboardPopup } from '../view/ClipboardPopup';
 import { showMapSelectPopup, showMapPreviewPopup } from '../view/MapPopup';
-import { SOURCE, MAP, WATCH_JOB, WATCH_URL, TRANSFORM, FILE_DEFAULTS, SEPARATORS, ACTIONS, PAGINATION } from '../constants';
-import { stateToPTIArray, loadFile, validateTransform, validateFileSettings, parseCoordinateValue, is3DSystem, getLabelForMarker } from '../helper';
+import { SOURCE, MAP, WATCH_JOB, WATCH_URL, FILE_DEFAULTS, SEPARATORS, ACTIONS, PAGINATION } from '../constants';
+import { stateToPTIArray, loadFile, validateTransform, parseCoordinateValue, is3DSystem, getLabelForMarker } from '../helper';
 import { parseFile, parseFileContents, parseValue } from './FileParser';
 
 const getInitialState = () => ({
@@ -234,7 +234,7 @@ class UIHandler extends StateHandler {
         const onConfirm = () => {
             this.updateState({ results: [] });
             onChange();
-            this.transformToArray('A2A');
+            this.transform();
         };
         this.confirmPopup = showConfirmPopup('confirm.title', 'confirm.results', onConfirm, () => this.closeConfirmPopup(), onChange);
     }
@@ -457,6 +457,14 @@ class UIHandler extends StateHandler {
         this.infoPopup = showInfoPopup(title, paragraphs, listItems, () => this.closeInfoPopup());
     }
 
+    showConfirmTransform (warningKeys) {
+        this.infoPopup?.close();
+        const listItems = warningKeys.map(key => this.loc(`flyout.transform.warnings.${key}`));
+        const title = this.loc('flyout.transform.warnings.title');
+        const paragraphs = [this.loc('flyout.transform.warnings.message')];
+        this.infoPopup = showInfoPopup(title, paragraphs, listItems, () => this.closeInfoPopup(), () => this.transformToArray());
+    }
+
     closeInfoPopup () {
         this.infoPopup?.close();
         this.infoPopup = null;
@@ -470,31 +478,17 @@ class UIHandler extends StateHandler {
         this.closeClipboard();
     }
 
-    validate (stepOrType) {
-        const state = this.getState();
-        const isTransform = TRANSFORM.includes(stepOrType);
-        let errors = isTransform ? validateTransform(state, stepOrType) : [];
-        if (!isTransform) {
-            if (stepOrType === 'srs' && (!state.inputSrs || !state.outputSrs)) {
-                errors.push('crs');
-            }
-            if (stepOrType === 'inputSrs' && !state.inputSrs) {
-                errors.push('srs');
-            }
-            if (stepOrType === 'ouputSrs' && !state.outputSrs) {
-                errors.push('srs');
-            }
-            if (stepOrType === 'importFile') {
-                errors = [...errors, ...validateFileSettings(state, 'import')];
-            }
-            if (stepOrType === 'exportFile') {
-                errors = [...errors, ...validateFileSettings(state, 'export')];
-            }
-        }
+    transform () {
+        const { warnings, errors } = validateTransform(this.getState());
         if (errors.length) {
             this.showValidationError(errors);
+            return;
         }
-        return errors.length > 0;
+        if (warnings.length) {
+            this.showConfirmTransform(warnings);
+            return;
+        }
+        this.transformToArray();
     }
 
     transformToFile (transformType) {
@@ -577,16 +571,12 @@ class UIHandler extends StateHandler {
             this.updateState({ loading: false });
         });
     }
-
-    transformToArray (transformType) {
-        // TODO: confirm 2Dto3D and 3Dto2D (transform.warnings)
-        const state = this.getState();
-        if (this.validate(transformType)) {
-            return;
-        }
+    // TODO: replace with new
+    transformToArray () {
+        const transformType = 'A2A';
         this.updateState({ loading: true });
 
-        const { params, body } = stateToPTIArray(state, transformType, false);
+        const { params, body } = stateToPTIArray(this.getState(), transformType, false);
         fetch(Oskari.urls.getRoute('CoordinateTransformation', params), {
             method: 'POST',
             headers: {
@@ -694,7 +684,7 @@ const wrapped = controllerMixin(UIHandler, [
     'confirmClearTables',
     'showOnMap',
     'transformToFile',
-    'transformToArray',
+    'transform',
     'showInfo',
     'showFileSettings',
     'onAction',

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -192,7 +192,7 @@ class UIHandler extends StateHandler {
     swapCoordinates () {
         const { coordinates } = this.getState();
         const swapped = coordinates.map(c => ({ ...c, x: c.y, y: c.x }));
-        this.updateState({ coordinates: swapped });
+        this.updateState({ coordinates: swapped, transformed: false });
     }
 
     // TODO: refactor

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -5,7 +5,7 @@ import { showConfirmPopup } from '../view/ConfirmPopup';
 import { showClipboardPopup } from '../view/ClipboardPopup';
 import { showMapSelectPopup, showMapPreviewPopup } from '../view/MapPopup';
 import { SOURCE, MAP, WATCH_JOB, WATCH_URL, FILE_DEFAULTS, SEPARATORS, ACTIONS, PAGINATION } from '../constants';
-import { stateToPTIArray, loadFile, validateTransform, parseCoordinateValue, is3DSystem, getLabelForMarker } from '../helper';
+import { stateToPTIArray, loadFile, validateTransform, validateCoordinate, parseCoordinateValue, is3DSystem, getDimension, getLabelForMarker } from '../helper';
 import { parseFile, parseFileContents, parseValue } from './FileParser';
 
 const getInitialState = () => ({
@@ -145,6 +145,13 @@ class UIHandler extends StateHandler {
     addCoordinate (coordinate) {
         const { coordinates } = this.getState();
         this.updateState({ coordinates: [...coordinates, coordinate] });
+    }
+
+    cleanInputCoordinates () {
+        const { coordinates, inputSrs, inputHeightSrs } = this.getState();
+        const input3D = getDimension(inputSrs, inputHeightSrs) === 3;
+        const cleaned = coordinates.filter(coord => validateCoordinate(coord, input3D));
+        this.updateState({ coordinates: cleaned });
     }
 
     updateCoordinate (index, coordinate) {
@@ -462,7 +469,11 @@ class UIHandler extends StateHandler {
         const listItems = warningKeys.map(key => this.loc(`flyout.transform.warnings.${key}`));
         const title = this.loc('flyout.transform.warnings.title');
         const paragraphs = [this.loc('flyout.transform.warnings.message')];
-        this.infoPopup = showInfoPopup(title, paragraphs, listItems, () => this.closeInfoPopup(), () => this.transformToArray());
+        const onConfirm = () => {
+            this.cleanInputCoordinates();
+            this.transformToArray();
+        };
+        this.infoPopup = showInfoPopup(title, paragraphs, listItems, () => this.closeInfoPopup(), onConfirm);
     }
 
     closeInfoPopup () {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -28,7 +28,7 @@ export const getSrsUnit = srs => {
     return unit || 'metric';
 };
 
-const validateCoordinate = (coord, is3D) => {
+export const validateCoordinate = (coord, is3D) => {
     if (coord.valid === false) {
         return false;
     }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -28,6 +28,15 @@ export const getSrsUnit = srs => {
     return unit || 'metric';
 };
 
+const validateCoordinate = (coord, is3D) => {
+    if (coord.valid === false) {
+        return false;
+    }
+    const { x, y, z } = coord;
+    const array = is3D ? [x, y, z] : [x, y];
+    return !array.some(c => typeof c !== 'number' || isNaN(c));
+};
+
 export const validateTransform = (state) => {
     const { inputSrs, outputSrs, inputHeightSrs, outputHeightSrs, coordinates } = state;
     const errors = [];

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -51,6 +51,10 @@ export const validateTransform = (state) => {
     if ( !input3D && outputSystem === 'PROJ_3D') {
         errors.push('xyz');
     }
+    // No need to check warnings
+    if (errors.length) {
+        return { errors, warnings };
+    }
     if (input3D !== output3D) {
         warnings.push(input3D ? '3DTo2D' : '2DTo3D');
     }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -28,34 +28,31 @@ export const getSrsUnit = srs => {
     return unit || 'metric';
 };
 
-export const validateTransform = (state, type) => {
-    if (type === 'F2R') {
-        return validateFileSettings(state, 'import');
-    }
-    if (type === 'A2A') {
-        return validateSelections(state);
-    }
-    if (type === 'F2A') {
-        return [...validateSelections(state), ...validateFileSettings(state, 'import')];
-    }
-    // import settings are validated on import
-    if (type === 'A2F' || type === 'F2F') {
-        return [...validateSelections(state), ...validateFileSettings(state, 'export')];
-    }
-    return ['message'];
-};
-const validateSelections = (state) => {
-    const { inputSrs, outputSrs, inputHeightSrs } = state;
+export const validateTransform = (state) => {
+    const { inputSrs, outputSrs, inputHeightSrs, outputHeightSrs, coordinates } = state;
     const errors = [];
-    // TODO: set import, set export, transform => split ??
+    const warnings = [];
+    const input3D = getDimension(inputSrs, inputHeightSrs) === 3;
+    const output3D = getDimension(outputSrs, outputHeightSrs) === 3;
+
     if (!inputSrs || !outputSrs) {
         errors.push('crs');
     }
-    const { system } = SRS.find(s => s.value === outputSrs) || {};
-    if (getDimension(inputSrs, inputHeightSrs) !== 3 && system === 'PROJ_3D') {
+    const { system: outputSystem } = SRS.find(s => s.value === outputSrs) || {};
+    if ( !input3D && outputSystem === 'PROJ_3D') {
         errors.push('xyz');
     }
-    return errors;
+    if (input3D !== output3D) {
+        warnings.push(input3D ? '3DTo2D' : '2DTo3D');
+    }
+    if (coordinates.some(coord => !validateCoordinate(coord, input3D))) {
+        warnings.push('coordinates');
+    }
+    if (coordinates.some(coord => !validateCoordInBounds(coord, inputSrs))) {
+        warnings.push('bbox');
+    }
+    // previously: show warning for > 10MB files => coordinates.length > 1000 etc??
+    return { errors, warnings };
 };
 
 export const validateFileSettings = (state, type) => {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -87,8 +87,11 @@ Oskari.registerLocalization(
             "transform": {
                 "warnings": {
                     "title": "Warning!",
-                    "3DTo2D": "The selected input information contains height values, but the output information does not. Output coordinates will therefore not include height values. Do you want to continue?",
-                    "2DTo3D": "The selected output information contains height values, but the input information does not. The height values 0 and height system N2000 will be added to the input information. Do you want to continue?",
+                    "message": "Please note the following restrictions on selections or coordinates before the transform. Do you want to continue?",
+                    "3DTo2D": "The selected input information contains height values, but the output information does not. Output coordinates will therefore not include height values.",
+                    "2DTo3D": "The selected output information contains height values, but the input information does not. The height values 0 and height system N2000 will be added to the input information.",
+                    "coordinates": "There are invalid rows in the coordinates to be transformed. The invalid rows will be removed before transform.",
+                    "bbox": "The coordinates to be transformed are outside the coverage area of ​​the source coordinate system. The coordinate values ​​must be in the axis order defined by the source coordinate system.",
                     "largeFile": "The transformation of large files can take several minutes."
                 },
                 "validateErrors": {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -92,8 +92,11 @@ Oskari.registerLocalization(
             "transform": {
                 "warnings": {
                     "title": "Huomio!",
-                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan. Haluatko jatkaa?",
-                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000. Haluatko jatkaa?",
+                    "message": "Huomioi seuraavat rajoitukset valinnoissa tai koordinaateissa ennnen kuin teeet muunnoksen. Haluatko jatkaa?",
+                    "3DTo2D": "Valitsemissasi lähtötiedoissa on mukana korkeusarvoja, mutta tulostiedoissa ei. Tuloskoordinaatteihin ei siis tule korkeusarvoja mukaan.",
+                    "2DTo3D": "Valitsemissasi lähtötiedoissa ei ole korkeusarvoja, mutta tulostiedoissa on. Lähtöaineiston korkeusarvoiksi lisätään 0 ja korkeusjärjestelmäksi N2000.",
+                    "coordinates": "Muunnettavissa koordinaateissa on virheellisiä rivejä. Virheelliset rivit poistetaan ennen muunnosta.",
+                    "bbox": "Muunnettavia koordinaatteja on lähtökoordinaattijärjestelmän kattavuusalueen ulkopuolella. Koordinaattien arvot tulee olla lähdejärjestelmän määrittelemässä järjestyksessä.",
                     "largeFile": "Isojen tiedostojen muuntaminen voi kestää useita minuutteja."
                 },
                 "validateErrors": {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -87,8 +87,11 @@ Oskari.registerLocalization(
             "transform": {
                 "warnings": {
                     "title": "Observera!",
-                    "3DTo2D": "I de utgångsuppgifter du valt finns höjdvärden, men inte i resultatuppgifterna. Höjvärden ingår alltså inte i resultatkoordinaterna. Vill du fortsätta?",
-                    "2DTo3D": "I de resultatuppgifter du valt finns höjdvärden, men inte i utgångsuppgifterna. Utgångsmaterialet ges höjdvärdet 0 och höjdsystemet N2000. Vill du fortsätta?",
+                    "message": "Observera följande begränsningar för val eller koordinater före transformationen. Vill du fortsätta?",
+                    "3DTo2D": "I de utgångsuppgifter du valt finns höjdvärden, men inte i resultatuppgifterna. Höjvärden ingår alltså inte i resultatkoordinaterna.",
+                    "2DTo3D": "I de resultatuppgifter du valt finns höjdvärden, men inte i utgångsuppgifterna. Utgångsmaterialet ges höjdvärdet 0 och höjdsystemet N2000.",
+                    "coordinates": "Det finns ogiltiga rader i koordinaterna som ska transformeras. De ogiltiga raderna kommer att tas bort före transformationen.",
+                    "bbox": "Koordinaterna som ska transformeras ligger utanför täckningsområde av referenssystemet för koordinater. Koordinatvärdena måste vara i den axelordning som definieras av referenssystemet för koordinater.",
                     "largeFile": "Transformation av stora filer kan ta flera minuter."
                 },
                 "validateErrors": {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/FlyoutContent.jsx
@@ -30,7 +30,6 @@ const StyledButtonContainer = styled(ButtonContainer)`
 
 export const FlyoutContent = ({
     controller,
-    source,
     sources,
     coordinates,
     results,
@@ -42,7 +41,6 @@ export const FlyoutContent = ({
     pagination
 }) => {
     const [ minimalSrs, setMinimalSrs ] = useState(true);
-    const transformType = source === 'file' ? 'F2A' : 'A2A';
     // Have to check here to use same height for input & output table headers
     const transform3D = getDimension(inputSrs, inputHeightSrs) === 3 || getDimension(outputSrs, outputHeightSrs) === 3;
     return (
@@ -73,7 +71,7 @@ export const FlyoutContent = ({
                     </Button>
                 </div>
                 <div className='t_transform'>
-                    <Button type='primary' className='t_table' disabled={transformed} onClick={() => controller.transformToArray(transformType)}>
+                    <Button type='primary' className='t_table' disabled={transformed} onClick={() => controller.transform()}>
                         <Message messageKey='actions.transform'/>
                     </Button>
                     <Button type='primary' className='t_file' disabled={!transformed} onClick={() => controller.showFileSettings('export')}>
@@ -87,7 +85,6 @@ export const FlyoutContent = ({
 
 FlyoutContent.propTypes = {
     loading: PropTypes.bool,
-    source: PropTypes.string,
     transformType: PropTypes.string,
     inputSrs: PropTypes.string,
     outputSrs: PropTypes.string,

--- a/bundles/paikkatietoikkuna/coordinatetransformation/view/InfoPopup.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/view/InfoPopup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { showPopup } from 'oskari-ui/components/window';
+import { ButtonContainer, PrimaryButton, SecondaryButton } from 'oskari-ui/components/buttons';
 import { BUNDLE } from '../constants';
 
 const POPUP_OPTIONS = {
@@ -24,17 +25,30 @@ const List = ({ items }) => {
         </ul>
     )
 };
-const getContent = (paragraphs, listItems) => (
-    <Content>
-        {paragraphs.map((p,i) => <Paragraph key={`p_${i}`}>{p}</Paragraph>)}
-        <List items={listItems} />
-    </Content>
-);
+const getContent = (paragraphs, listItems, onClose, onConfirm) => {
+    const renderButtons = typeof onClose === 'function' && typeof onConfirm === 'function';
+    const confirm = () => {
+        onConfirm();
+        onClose();
+    };
+    return(
+        <Content>
+            {paragraphs.map((p,i) => <Paragraph key={`p_${i}`}>{p}</Paragraph>)}
+            <List items={listItems} />
+            { renderButtons && (
+                <ButtonContainer>
+                    <SecondaryButton type='cancel' onClick={() => onClose()} />
+                    <PrimaryButton type='yes' onClick={() => confirm()}/>
+                </ButtonContainer>
+            )}
+        </Content>
+    );
+};
 
-export const showInfoPopup = (title, paragraphs, listItems, onClose) => {
+export const showInfoPopup = (title, paragraphs, listItems, onClose, onConfirm) => {
     const controls = showPopup(
         title,
-        getContent(paragraphs, listItems),
+        getContent(paragraphs, listItems, onClose, onConfirm),
         onClose,
         POPUP_OPTIONS
     );


### PR DESCRIPTION
- show confirm before transform for invalid coords, coords outside bbox, 2Dto3D, 3Dto2D
==> used errors/info popup because it support lists. for now there is too many popups and popups should be refactored (content, buttons, options or something more generic)
- removed some old code (steps were for Wizard, transformType isn't needed anymore)
-  