### PR TITLE
Komu file settings

### DIFF
--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/FileSettings.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/FileSettings.jsx
@@ -57,6 +57,8 @@ const SelectOption = ({id, values, onChange, controller, mandatory = true}) =>
 
 export const ImportFile = ({ import: values, inputSrs, files, fileContents, controller }) => {
     const onChange = (key, value) => controller.setFileSetting('import', key, value);
+    // file parser handles count instead of boolean TODO: change to number input ?
+    const onPrefix = (key, checked) => controller.setFileSetting('import', 'prefixColCount', checked ? 1 : 0);
     return (
         <Content>
             <FileInput mandatory onFiles={controller.setFiles} files={files} { ...FILE_INPUT_PROPS } />
@@ -64,7 +66,7 @@ export const ImportFile = ({ import: values, inputSrs, files, fileContents, cont
             <SelectOption id='coordinateSeparator' controller={controller} onChange={onChange} values={values}/>
             <SelectOption id='decimalSeparator' controller={controller} onChange={onChange} values={values}/>
             { showDegreeUnit(inputSrs) && <SelectOption id='unit' mandatory={isDegreeSystem(inputSrs)} controller={controller} onChange={onChange} values={values}/> }
-            <CheckboxOption id='prefixId' locPath='prefixes.input' controller={controller} onChange={onChange} values={values}/>
+            <CheckboxOption id='prefixColCount' locPath='prefixes.input' controller={controller} onChange={onPrefix} values={values}/>
             <FilePreview fileContents={fileContents} dataFormat={values.unit} />
         </Content>
     );
@@ -72,8 +74,10 @@ export const ImportFile = ({ import: values, inputSrs, files, fileContents, cont
 
 export const ExportFile = ({ export: values, outputSrs, controller, fileContents }) => {
     const onChange = (key, value) => controller.setFileSetting('export', key, value);
-    const { lineEndings = [], headerLines = [] , prefixColCount } = fileContents || {};
-    const prefixIdLocPath = prefixColCount > 0 ? 'prefixes.fromFile' : 'prefixes.generate'; // or prefixes.length > 0
+    // file writer handles count instead of boolean TODO: change to number input ?
+    const onPrefix = (key, checked) => controller.setFileSetting('export', 'prefixColCount', checked ? 1 : 0);
+    const { lineEndings = [], headerLines = [], prefixes = [] } = fileContents || {};
+    const prefixLocPath = prefixes.length > 0 ? 'prefixes.fromFile' : 'prefixes.generate';
     const hasLineEndings = lineEndings.length > 0;
     const hasHeaders = headerLines.length > 0;
     return (
@@ -86,7 +90,7 @@ export const ExportFile = ({ export: values, outputSrs, controller, fileContents
             <SelectOption id='lineSeparator' controller={controller} onChange={onChange} values={values}/>
             <CheckboxOption id='createHeader' controller={controller} onChange={onChange} values={values}/>
             { hasHeaders && <CheckboxOption id='writeHeaders' controller={controller} onChange={onChange} values={values}/> }
-            <CheckboxOption id='prefixId' locPath={prefixIdLocPath} controller={controller} onChange={onChange} values={values}/>
+            <CheckboxOption id='prefixColCount' locPath={prefixLocPath} controller={controller} onChange={onPrefix} values={values}/>
             <CheckboxOption id='axisFlip' controller={controller} onChange={onChange} values={values}/>
             <CheckboxOption id='writeCardinals' controller={controller} onChange={onChange} values={values}/>
             { hasLineEndings && <CheckboxOption id='writeLineEndings' controller={controller} onChange={onChange} values={values}/> }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/components/FileSettings.jsx
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/components/FileSettings.jsx
@@ -46,7 +46,7 @@ const CheckboxOption = ({id, values, onChange, controller, locPath}) => (
             <Message messageKey={`fileSettings.options.${locPath || id}`} />
         </Checkbox>
         <span onClick={() => controller.showInfo(id)}>
-            <InfoIcon title={<Message messageKey={`infoPopup.${id}.title`}/>}/>
+            <InfoIcon title={<Message messageKey={`infoPopup.${id}.info`}/>}/>
         </span>
     </Wrapper>
 );

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
@@ -1,4 +1,4 @@
-import { DEGREE, HOUR_TO_MIN, HOUR_TO_SEC, DEC_TO_GRAD, DEC_TO_RAD } from '../constants';
+import { SRS, DEGREE, HOUR_TO_MIN, HOUR_TO_SEC, DEC_TO_GRAD, DEC_TO_RAD  } from '../constants';
 
 export const parseFile = (file) => {
     return new Promise((resolve, reject) => {
@@ -21,7 +21,9 @@ const addToArray = (array, index, value) => {
     }
 };
 
-export const parseFileContents = (lines = [], delimiter = ';', headerLineCount = 0, prefixColCount = 0, dimension = 2) => {
+export const parseFileContents = (lines = [], delimiter = ';', headerLineCount = 0, prefixColCount = 0) => {
+    // parse always x,y,z to data
+    const dimension = 3; //TODO: data[2] or z could contain lineEnding stuff for 2D
     const headerMetadata = {
         headerLines: [],
         headers: []
@@ -34,6 +36,7 @@ export const parseFileContents = (lines = [], delimiter = ';', headerLineCount =
         // remove possible id column(s) at the start
         headerMetadata.headers = headers.slice(prefixColCount);
         linesWithData = lines.slice(headerLineCount);
+        headerMetadata.srs = headerLines.map(line => detectEpsgCode(line)).find(found => found);
     }
     const decimalSeparator = detectDecimalSeparator(linesWithData[0], delimiter);
     const data = [];
@@ -51,11 +54,14 @@ export const parseFileContents = (lines = [], delimiter = ';', headerLineCount =
             }
         });
     });
-
-    return {
-        delimiter,
+    const settings = {
         decimalSeparator,
-        prefixColCount,
+        coordinateSeparator: delimiter,
+        headerLineCount,
+        prefixColCount
+    };
+    return {
+        settings,
         data,
         prefixes,
         lineEndings,
@@ -115,11 +121,12 @@ export const parseValue = (value, format = 'metric') => {
 };
 
 const interpretFileContents = (lines = []) => {
-    // TODO: doesn't work correctly with quite common files (header, semicolon, point)
-    // Maybe try to detect headers first as header line spaces leads to ' ' delimeter
-    const delimiter = detectDelimiter(lines[0]);
+    const midIndex = Math.floor(lines.length / 2);
+    const delimiter = detectDelimiter(lines[midIndex]);
+    // could srs bbox be used to detect prefix
+    const prefixColCount = countPrefixColoumns(lines[midIndex], lines[midIndex + 1], delimiter);
     const headerLineCount = countHeaders(lines, delimiter);
-    return parseFileContents(lines, delimiter, headerLineCount);
+    return parseFileContents(lines, delimiter, headerLineCount, prefixColCount);
 };
 
 const detectDecimalSeparator = (line = '', delimiter = ';') => {
@@ -149,6 +156,15 @@ const detectDelimiter = (line) => {
     return bestDelimiter;
 };
 
+const detectEpsgCode = (headerLine) => {
+    const codes = headerLine
+        .replace(/\D/g, ' ') // replace non digits with white space
+        .split(' ')
+        .filter(num => num.length === 4 || num.length === 5)
+        .map(num => `EPSG:${num}`);
+    return codes.find(code => SRS.find(s => s.value === code));
+};
+
 const isNumericRow = (row, delimiter) => {
     const cells = row.split(delimiter).map(cell => cell.trim());
 
@@ -158,10 +174,18 @@ const isNumericRow = (row, delimiter) => {
     });
 };
 
+const countNumericCells = (row, delimiter) => {
+    const cells = row.split(delimiter).map(cell => cell.trim());
+    return cells.filter(cell => {
+        const normalized = cell.replace(',', '.');
+        return !isNaN(normalized) && normalized !== '';
+    }).length;
+};
+
 const countHeaders = (lines = [], delimiter) => {
     let headerLines = 0;
     for (let i = 0; i < lines.length;) {
-        if (isNumericRow(lines[i], delimiter)) {
+        if (countNumericCells(lines[i], delimiter) > 1) {
             headerLines = i;
             break;
         } else {
@@ -169,4 +193,25 @@ const countHeaders = (lines = [], delimiter) => {
         }
     }
     return headerLines;
+};
+
+const countPrefixColoumns = (row, nextRow, delimiter) => {
+    const cells = row.split(delimiter).map(cell => cell.trim());
+    const firstNumIndex = cells.findIndex(cell => !isNaN(cell));
+    if (firstNumIndex > 0) {
+        return firstNumIndex;
+    }
+    // TODO: how to figure numeric prefix (line number, srs bbox)
+    if (countNumericCells(row, delimiter) == 2) {
+        return 0;
+    }
+    if (nextRow) {
+        const nextCells = nextRow.split(delimiter).map(cell => cell.trim());
+        // use parse float (degree)
+        const isLineNumber = parseFloat(nextCells[0]) - parseFloat(cells[0]) === 1;
+        if (isLineNumber) {
+            return 1;
+        }
+    }
+    return 0;
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
@@ -1,4 +1,4 @@
-import { SRS, DEGREE, HOUR_TO_MIN, HOUR_TO_SEC, DEC_TO_GRAD, DEC_TO_RAD  } from '../constants';
+import { SRS, DEGREE, HOUR_TO_MIN, HOUR_TO_SEC, DEC_TO_GRAD, DEC_TO_RAD } from '../constants';
 
 export const parseFile = (file) => {
     return new Promise((resolve, reject) => {
@@ -23,7 +23,7 @@ const addToArray = (array, index, value) => {
 
 export const parseFileContents = (lines = [], delimiter = ';', headerLineCount = 0, prefixColCount = 0) => {
     // parse always x,y,z to data
-    const dimension = 3; //TODO: data[2] or z could contain lineEnding stuff for 2D
+    const dimension = 3; // TODO: data[2] or z could contain lineEnding stuff for 2D
     const headerMetadata = {
         headerLines: [],
         headers: []
@@ -173,6 +173,7 @@ const detectEpsgCode = (headerLine) => {
     return codes.find(code => SRS.find(s => s.value === code));
 };
 
+// eslint-disable-next-line no-unused-vars
 const isNumericRow = (row, delimiter) => {
     const cells = row.split(delimiter).map(cell => cell.trim());
 

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
@@ -54,7 +54,14 @@ export const parseFileContents = (lines = [], delimiter = ';', headerLineCount =
                 addToArray(lineEndings, lineIndex, cell);
             }
         });
+        // Fix for strange error: prefixColCount and wrong headerLineCount (too small)
+        // linesWithData gets header row which may not have delimeter => whole header line goes to prefix array
+        // to be sure that data get filled correctly for preview and parsing
+        if (!data[lineIndex]) {
+            data[lineIndex] = [];
+        }
     });
+
     const settings = {
         decimalSeparator,
         coordinateSeparator: delimiter,

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileParser.js
@@ -38,6 +38,7 @@ export const parseFileContents = (lines = [], delimiter = ';', headerLineCount =
         linesWithData = lines.slice(headerLineCount);
         headerMetadata.srs = headerLines.map(line => detectEpsgCode(line)).find(found => found);
     }
+    // TODO: always uses detected => remove option from import settings OR pass & use selected
     const decimalSeparator = detectDecimalSeparator(linesWithData[0], delimiter);
     const data = [];
     const prefixes = [];

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileWriter.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/FileWriter.js
@@ -5,7 +5,6 @@ const CRS = 'Coordinate Reference System';
 
 const toDegree = (coord, unit, decimals) => { //, isLon)
     if (unit === 'DD' || unit === 'degree') {
-        // TODO: prefix 0 ??
         return coord.toFixed(decimals);
     }
     if (unit === 'gradian') {
@@ -56,7 +55,7 @@ const getFileContent = ({
         coordinateSeparator,
         lineSeparator,
         axisFlip,
-        prefixId,
+        prefixColCount,
         writeCardinals,
         writeLineEndings
     } = settings;
@@ -85,7 +84,7 @@ const getFileContent = ({
         row = row.map(r => replace ? r.replace('.', ',') : r)
             .map((r, i) => writeCardinals ? addCardinal(r, i === lonIndex) : r);
 
-        if (prefixId) {
+        if (prefixColCount > 0) {
             // use stored from imported file if available
             const ids = prefixesFromImport
                 ? prefixes[index] || ['']
@@ -97,6 +96,8 @@ const getFileContent = ({
             const ending = lineEndings[index] || [''];
             ending.forEach(p => row.push(p));
         }
+        // TODO: can prefixes and lineEndings lengths vary? now adds only one empty if missing
+        // => every row length must be same to get valid csv
         return row.join(coordinateSeparator);
     }).join(lineSeparator);
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -4,8 +4,8 @@ import { showFilePopup } from '../view/FilePopup';
 import { showConfirmPopup } from '../view/ConfirmPopup';
 import { showClipboardPopup } from '../view/ClipboardPopup';
 import { showMapSelectPopup, showMapPreviewPopup } from '../view/MapPopup';
-import { SOURCE, MAP, WATCH_JOB, WATCH_URL, FILE_DEFAULTS, ACTIONS, PAGINATION } from '../constants';
-import { stateToPTIArray, stateToTransformRequest, stateToKomuRequest, parseKomuResponse, validateFileSettings, validateTransform, validateCoordinate, parseCoordinateValue, is3DSystem, getDimension, getLabelForMarker } from '../helper';
+import { SOURCE, MAP, WATCH_JOB, WATCH_URL, FILE_DEFAULTS, ACTIONS, PAGINATION, SRS } from '../constants';
+import { stateToPTIArray, stateToTransformRequest, stateToKomuRequest, parseKomuResponse, validateFileSettings, validateTransform, validateCoordinate, parseCoordinateValue, is3DSystem, getDimension, getLabelForMarker, getCoordinatesExtent } from '../helper';
 import { parseFile, parseFileContents, parseValue } from './FileParser';
 import { exportStateToFile } from './FileWriter';
 
@@ -45,6 +45,7 @@ class UIHandler extends StateHandler {
         this.baseUrl = conf.url;
         this.transformFunction = this.getTransformFunction(conf);
         Oskari.urls.set(WATCH_JOB, WATCH_URL);
+        this.log = Oskari.log('CoordTransHandler');
     }
 
     getTransformFunction ({ url, contentType }) {
@@ -184,8 +185,8 @@ class UIHandler extends StateHandler {
                 .map(([x, y, z]) => ({ x, y, z }));
             this.addSourceToState('clipboard');
             this.updateState({ coordinates, transformed: false });
-        } catch {
-            // TODO: error handling
+        } catch (err) {
+            this.log.debug(err);
             Messaging.error(this.loc('transform.errors.paste'));
         }
     }
@@ -299,7 +300,7 @@ class UIHandler extends StateHandler {
                 import: newSettings // { ...settings, ...contents.settings }
             });
         }).catch(err => {
-            console.log(err);
+            this.log.debug(err);
             Messaging.error(this.log('transform.errors.import'));
         });
     }
@@ -517,8 +518,20 @@ class UIHandler extends StateHandler {
             this.showConfirmTransform(warnings);
             return;
         }
+        if (this.log.isDebug()) {
+            this.debugTransform();
+        }
         this.transformFunction();
     }
+
+    debugTransform () {
+        const { inputSrs, coordinates } = this.getState();
+        const { bounds = [] } = SRS.find(s => s.value === inputSrs) || {};
+        const info = getCoordinatesExtent(coordinates, inputSrs);
+        this.log.debug('Projected bounds for:', inputSrs, bounds);
+        Object.keys(info).forEach(key => this.log.debug(key, '=>', info[key]));
+    }
+
 
     importFileContentsToInputTable () {
         const errors = validateFileSettings(this.getState(), 'import');
@@ -549,7 +562,7 @@ class UIHandler extends StateHandler {
         try {
             exportStateToFile(state);
         } catch (err) {
-            console.log(err);
+            this.log.debug(err);
             Messaging.error(this.loc('transform.errors.export'));
         }
         this.updateState({ loading: false });
@@ -702,7 +715,6 @@ class UIHandler extends StateHandler {
     showResponseError (response) {
         const { error, info } = response || {};
         const key = info?.errorKey || error?.errorKey || 'generic';
-        Oskari.log('CoordTransHandler').error(error);
         Messaging.error(this.loc(`transform.errors.${key}`));
         this.updateState({ loading: false });
     }

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -433,7 +433,7 @@ class UIHandler extends StateHandler {
             const { headerLineCount, ...restSettings } = state.fileContents.settings;
             const writeHeaders = headerLineCount > 0;
             // use default values from import file
-            this.updateState({ export: { ...state.export, ...restSettings, writeHeaders }});
+            this.updateState({ export: { ...state.export, ...restSettings, writeHeaders } });
         }
         this.filePopup = showFilePopup(type, this.getState(), this.getController(), () => this.closeFileSettings());
     }
@@ -531,7 +531,6 @@ class UIHandler extends StateHandler {
         this.log.debug('Projected bounds for:', inputSrs, bounds);
         Object.keys(info).forEach(key => this.log.debug(key, '=>', info[key]));
     }
-
 
     importFileContentsToInputTable () {
         const errors = validateFileSettings(this.getState(), 'import');

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -427,6 +427,13 @@ class UIHandler extends StateHandler {
 
     showFileSettings (type) {
         this.filePopup?.close();
+        const state = this.getState();
+        if (type === 'export' && state.fileContents) {
+            const { headerLineCount, ...restSettings } = state.fileContents.settings;
+            const writeHeaders = headerLineCount > 0;
+            // use default values from import file
+            this.updateState({ export: { ...state.export, ...restSettings, writeHeaders }});
+        }
         this.filePopup = showFilePopup(type, this.getState(), this.getController(), () => this.closeFileSettings());
     }
 

--- a/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/handler/ViewHandler.js
@@ -276,22 +276,27 @@ class UIHandler extends StateHandler {
         if (files.length === 0) {
             this.updateState({
                 files: [],
-                fileContents: undefined
+                fileContents: null
             });
         }
         if (files.length !== 1) {
             return;
         }
         parseFile(files[0]).then(contents => {
-            // TODO: maybe set from content only if default settings (don't override user selects)
+            const { inputSrs, import: settings } = this.getState();
+            // use detected settings only if user hasn't selected value
+            // Maybe this isn't needed if detect functions works right
+            const newSettings = { ...settings };
+            Object.keys(contents.settings).forEach(key => {
+                if (newSettings[key] === FILE_DEFAULTS.import[key]) {
+                    newSettings[key] = contents.settings[key];
+                }
+            });
             this.updateState({
+                inputSrs: contents.srs || inputSrs,
                 files,
                 fileContents: contents,
-                import: {
-                    headerLineCount: contents.headerLines.length,
-                    coordinateSeparator: contents.delimiter,
-                    decimalSeparator: contents.decimalSeparator
-                }
+                import: newSettings // { ...settings, ...contents.settings }
             });
         }).catch(err => {
             console.log(err);
@@ -301,7 +306,7 @@ class UIHandler extends StateHandler {
 
     setFileSetting (type, key, value) {
         const settings = this.getState()[type];
-        const newTypeState = {
+        const updated = {
             [type]: {
                 ...settings,
                 [key]: value
@@ -310,29 +315,12 @@ class UIHandler extends StateHandler {
         if (type === 'import') {
             const { fileContents } = this.getState();
             if (fileContents) {
-                // The UI is only a checkbox atm but parser takes a number of prefix columns
-                let prefixColCount = fileContents.prefixColCount;
-                if (key === 'prefixId') {
-                    prefixColCount = value ? 1 : 0;
-                }
-
+                const { headerLineCount, coordinateSeparator, prefixColCount } = updated[type];
                 // parseFileContents() to update parsing based on the new selection
-                const coordSeparator = newTypeState.import.coordinateSeparator;
-                newTypeState.fileContents = parseFileContents(fileContents.lines, coordSeparator, newTypeState.import.headerLineCount, prefixColCount);
+                updated.fileContents = parseFileContents(fileContents.lines, coordinateSeparator, headerLineCount, prefixColCount);
             }
         }
-
-        this.updateState(newTypeState);
-    }
-
-    setImport (key, value) {
-        const current = this.getState().import;
-        this.updateState({ import: { ...current, [key]: value } });
-    }
-
-    setExport (key, value) {
-        const current = this.getState().export;
-        this.updateState({ export: { ...current, [key]: value } });
+        this.updateState(updated);
     }
 
     confirmClearTables () {

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -242,8 +242,8 @@ export const getCoordinatesExtent = (coordinates, srs) => {
     return {
         extent: [minX, minY, maxX, maxY],
         bbox: { left: minX, bottom: minY, right: maxX, top: maxY },
-        min: { x: swap ? minY : minX, y: swap ? minX : minY},
-        max: { x: swap ? maxY : maxX, y: swap ? maxX : maxY},
+        min: { x: swap ? minY : minX, y: swap ? minX : minY },
+        max: { x: swap ? maxY : maxX, y: swap ? maxX : maxY },
         wkt: `POLYGON ((${minX} ${minY}, ${maxX} ${minY}, ${maxX} ${maxY}, ${minX} ${maxY}, ${minX} ${minY}))`
     };
     // Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [wkt, { layerId: 'komu', centerTo: true }]);

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -209,6 +209,46 @@ export const getLabelForMarker = (coord, srs) => {
     */
 };
 
+// Added for debugging
+export const getCoordinatesExtent = (coordinates, srs) => {
+    if (!coordinates.length) {
+        return {};
+    }
+    const swap = !isLonFirst(srs);
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    coordinates.forEach(({ x, y }, i) => {
+        const coord = swap ? [y, x] : [x, y];
+        if (coord.some(c => typeof c !== 'number' || isNaN(c))) {
+            Oskari.log('CoordTransHelper').warn('Invalid coord:', coord, 'at:', i);
+            return;
+        }
+        if (coord[0] < minX) {
+            minX = coord[0];
+        }
+        if (coord[0] > maxX) {
+            maxX = coord[0];
+        }
+        if (coord[1] < minY) {
+            minY = coord[1];
+        }
+        if (coord[1] > maxY) {
+            maxY = coord[1];
+        }
+    });
+    // wkt: left-bottom counterclockwise closed
+    return {
+        extent: [minX, minY, maxX, maxY],
+        bbox: { left: minX, bottom: minY, right: maxX, top: maxY },
+        min: { x: swap ? minY : minX, y: swap ? minX : minY},
+        max: { x: swap ? maxY : maxX, y: swap ? maxX : maxY},
+        wkt: `POLYGON ((${minX} ${minY}, ${maxX} ${minY}, ${maxX} ${maxY}, ${minX} ${maxY}, ${minX} ${minY}))`
+    };
+    // Oskari.getSandbox().postRequestByName('MapModulePlugin.AddFeaturesToMapRequest', [wkt, { layerId: 'komu', centerTo: true }]);
+};
+
 export const coordinateToMarker = (coord, isNew) => {
     const { colors, ...props } = MARKER;
     const { x, y, label } = coord;

--- a/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/helper.js
@@ -254,7 +254,7 @@ export const stateToKomuRequest = (state) => {
 
 export const parseKomuResponse = (text) => {
     return text.split(`;`).map(coord => {
-        const [x, y, z] = coord.split(',');
+        const [x, y, z] = coord.split(',').map(c => parseFloat(c));
         return { x, y, z };
     });
 };

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/en.js
@@ -359,7 +359,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "prefixId":{
+            "prefixColCount":{
                 "title":"Use identifiers",
                 "info": "Coordinate row starts with identifier",
                 "paragraphs": [

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/fi.js
@@ -361,7 +361,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "prefixId":{
+            "prefixColCount":{
                 "title":"Koordinaattiarvoja edeltää pisteen tunniste",
                 "info": "Koordinaattirivi alkaa tunnistetiedolla",
                 "paragraphs": [

--- a/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
+++ b/bundles/paikkatietoikkuna/coordinatetransformation/resources/locale/sv.js
@@ -358,7 +358,7 @@ Oskari.registerLocalization(
                 ],
                 "listItems" : []
             },
-            "prefixId":{
+            "prefixColCount":{
                 "title":"Använd identifierare",
                 "info": "Koordinatraden börjar med identifieraruppgift",
                 "paragraphs": [


### PR DESCRIPTION
File settings:
- use mid index for delimeter detection (if first line is header, white spaces caused wrong delimeter detection)
- detect prefixColCount
- detect EPSG code from header lines (loops 4 or 5 digits numbers)
- change detect header lines count to use at least 2 number cells (not all) to detect first data line (prefix or line endings might be non numeric)
- use default values from import file (user may want to use same format/syntax for exported file)
- handle prefixColCount in jsx

Fixes:
- parse result coordinates to float (for file export)
- use `info` as tooltip instead of title (file settings popup)
- parse file always with dimension 3 as srs and/or height might not be selected before import

Add debug transform:
`Oskari.log('CoordTransHandler').enableDebug(true)`
`Oskari.getSandbox().findRegisteredModuleInstance('coordinatetransformation').getFlyout().getHandler().debugTransform()`