### PR TITLE
Hackishly start myfeatures from frontend automatically

### DIFF
--- a/applications/geoportal/index.js
+++ b/applications/geoportal/index.js
@@ -49,6 +49,8 @@ jQuery(document).ready(function () {
             app.startApplication(function () {
                 var sb = Oskari.getSandbox();
                 gfiParamHandler(sb);
+                // TODO: move to db eventually
+                Oskari.app.playBundle({bundlename: 'myfeatures'});
             });
         },
         error: function (jqXHR, textStatus) {


### PR DESCRIPTION
So it's easier to remove in case needed for an unexpected change to prod. The next scheduled version should migrate myplaces/userlayers to myfeatures so we need to add it to db when doing that at the latest .